### PR TITLE
fix: remove .idea directory and fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,9 @@ go.work.sum
 .env
 
 # Editor/IDE
- .idea/
- .vscode/
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# デフォルトの無視対象ファイル
-/shelf/
-/workspace.xml
-# エディターベースの HTTP クライアントリクエスト
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/morning-call-api.iml" filepath="$PROJECT_DIR$/.idea/morning-call-api.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/morning-call-api.iml
+++ b/.idea/morning-call-api.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="Go" enabled="true" />
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
This pull request removes several project-specific configuration files for the JetBrains IDE from the repository. These files are typically not needed in version control and are often excluded to avoid sharing local IDE settings across different developers.

Removed JetBrains IDE configuration files:

* Project module configuration: Deleted `.idea/modules.xml` and `.idea/morning-call-api.iml`, which define project modules and settings. [[1]](diffhunk://#diff-0aae258f1732eac2acd4fcdd1af6d0737b4ec8d233136c3ba7c40b6d49aeda50L1-L8) [[2]](diffhunk://#diff-22d292f62893d04dbf295efc122c1ccaab55d294944a0a6c00b00becb2d91997L1-L9)
* Version control mapping: Deleted `.idea/vcs.xml`, which stores version control system mappings for the project.
* Git ignore for IDE files: Removed entries from `.idea/.gitignore` that excluded local IDE-specific files such as `workspace.xml`, `httpRequests/`, and `dataSources/`.