### PR TITLE
feat: define Repository interfaces for domain entities

### DIFF
--- a/internal/domain/repository/errors.go
+++ b/internal/domain/repository/errors.go
@@ -1,0 +1,30 @@
+package repository
+
+import "errors"
+
+// Common repository errors
+var (
+	// ErrNotFound はエンティティが見つからない場合のエラー
+	ErrNotFound = errors.New("entity not found")
+
+	// ErrAlreadyExists はエンティティが既に存在する場合のエラー
+	ErrAlreadyExists = errors.New("entity already exists")
+
+	// ErrInvalidArgument は不正な引数が渡された場合のエラー
+	ErrInvalidArgument = errors.New("invalid argument")
+
+	// ErrUpdateConflict は更新競合が発生した場合のエラー
+	ErrUpdateConflict = errors.New("update conflict")
+
+	// ErrTransactionFailed はトランザクションが失敗した場合のエラー
+	ErrTransactionFailed = errors.New("transaction failed")
+
+	// ErrConnectionFailed は接続エラーが発生した場合のエラー
+	ErrConnectionFailed = errors.New("connection failed")
+
+	// ErrTimeout はタイムアウトが発生した場合のエラー
+	ErrTimeout = errors.New("operation timeout")
+
+	// ErrPermissionDenied は権限がない場合のエラー
+	ErrPermissionDenied = errors.New("permission denied")
+)

--- a/internal/domain/repository/morning_call_repository.go
+++ b/internal/domain/repository/morning_call_repository.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+)
+
+// MorningCallRepository はモーニングコールエンティティの永続化を担うリポジトリインターフェース
+type MorningCallRepository interface {
+	// Create は新しいモーニングコールを作成する
+	Create(ctx context.Context, morningCall *entity.MorningCall) error
+
+	// FindByID はIDでモーニングコールを検索する
+	FindByID(ctx context.Context, id string) (*entity.MorningCall, error)
+
+	// Update はモーニングコール情報を更新する
+	Update(ctx context.Context, morningCall *entity.MorningCall) error
+
+	// Delete はモーニングコールを削除する
+	Delete(ctx context.Context, id string) error
+
+	// ExistsByID はIDでモーニングコールの存在を確認する
+	ExistsByID(ctx context.Context, id string) (bool, error)
+
+	// FindBySenderID は送信者IDでモーニングコールを検索する
+	FindBySenderID(ctx context.Context, senderID string, offset, limit int) ([]*entity.MorningCall, error)
+
+	// FindByReceiverID は受信者IDでモーニングコールを検索する
+	FindByReceiverID(ctx context.Context, receiverID string, offset, limit int) ([]*entity.MorningCall, error)
+
+	// FindByStatus はステータスでモーニングコールを検索する
+	FindByStatus(ctx context.Context, status valueobject.MorningCallStatus, offset, limit int) ([]*entity.MorningCall, error)
+
+	// FindScheduledBefore は指定時刻より前にスケジュールされたモーニングコールを検索する
+	FindScheduledBefore(ctx context.Context, time time.Time, offset, limit int) ([]*entity.MorningCall, error)
+
+	// FindScheduledBetween は指定期間内にスケジュールされたモーニングコールを検索する
+	FindScheduledBetween(ctx context.Context, start, end time.Time, offset, limit int) ([]*entity.MorningCall, error)
+
+	// FindActiveByUserPair は特定のユーザーペア間のアクティブなモーニングコールを検索する
+	FindActiveByUserPair(ctx context.Context, senderID, receiverID string) ([]*entity.MorningCall, error)
+
+	// CountBySenderID は送信者IDでモーニングコール数を取得する
+	CountBySenderID(ctx context.Context, senderID string) (int, error)
+
+	// CountByReceiverID は受信者IDでモーニングコール数を取得する
+	CountByReceiverID(ctx context.Context, receiverID string) (int, error)
+
+	// CountByStatus はステータスごとのモーニングコール数を取得する
+	CountByStatus(ctx context.Context, status valueobject.MorningCallStatus) (int, error)
+
+	// FindAll はすべてのモーニングコールを取得する（ページネーション対応）
+	FindAll(ctx context.Context, offset, limit int) ([]*entity.MorningCall, error)
+
+	// Count は総モーニングコール数を取得する
+	Count(ctx context.Context) (int, error)
+}

--- a/internal/domain/repository/relationship_repository.go
+++ b/internal/domain/repository/relationship_repository.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+)
+
+// RelationshipRepository は友達関係エンティティの永続化を担うリポジトリインターフェース
+type RelationshipRepository interface {
+	// Create は新しい友達関係を作成する
+	Create(ctx context.Context, relationship *entity.Relationship) error
+
+	// FindByID はIDで友達関係を検索する
+	FindByID(ctx context.Context, id string) (*entity.Relationship, error)
+
+	// Update は友達関係情報を更新する
+	Update(ctx context.Context, relationship *entity.Relationship) error
+
+	// Delete は友達関係を削除する
+	Delete(ctx context.Context, id string) error
+
+	// ExistsByID はIDで友達関係の存在を確認する
+	ExistsByID(ctx context.Context, id string) (bool, error)
+
+	// FindByUserPair は特定のユーザーペア間の関係を検索する
+	FindByUserPair(ctx context.Context, userID1, userID2 string) (*entity.Relationship, error)
+
+	// FindByRequesterID はリクエスト送信者IDで友達関係を検索する
+	FindByRequesterID(ctx context.Context, requesterID string, offset, limit int) ([]*entity.Relationship, error)
+
+	// FindByReceiverID はリクエスト受信者IDで友達関係を検索する
+	FindByReceiverID(ctx context.Context, receiverID string, offset, limit int) ([]*entity.Relationship, error)
+
+	// FindByUserID はユーザーIDで友達関係を検索する（送信者・受信者両方）
+	FindByUserID(ctx context.Context, userID string, offset, limit int) ([]*entity.Relationship, error)
+
+	// FindByStatus はステータスで友達関係を検索する
+	FindByStatus(ctx context.Context, status valueobject.RelationshipStatus, offset, limit int) ([]*entity.Relationship, error)
+
+	// FindFriendsByUserID はユーザーIDで友達（承認済み）関係を検索する
+	FindFriendsByUserID(ctx context.Context, userID string, offset, limit int) ([]*entity.Relationship, error)
+
+	// FindPendingRequestsByReceiverID は受信者IDで承認待ちリクエストを検索する
+	FindPendingRequestsByReceiverID(ctx context.Context, receiverID string, offset, limit int) ([]*entity.Relationship, error)
+
+	// FindPendingRequestsByRequesterID は送信者IDで承認待ちリクエストを検索する
+	FindPendingRequestsByRequesterID(ctx context.Context, requesterID string, offset, limit int) ([]*entity.Relationship, error)
+
+	// FindBlockedRelationshipsByUserID はユーザーIDでブロック関係を検索する
+	FindBlockedRelationshipsByUserID(ctx context.Context, userID string, offset, limit int) ([]*entity.Relationship, error)
+
+	// ExistsByUserPair は特定のユーザーペア間の関係の存在を確認する
+	ExistsByUserPair(ctx context.Context, userID1, userID2 string) (bool, error)
+
+	// AreFriends は2人のユーザーが友達関係かを確認する
+	AreFriends(ctx context.Context, userID1, userID2 string) (bool, error)
+
+	// IsBlocked は指定ユーザーがブロックされているかを確認する
+	IsBlocked(ctx context.Context, blockerID, blockedID string) (bool, error)
+
+	// CountFriendsByUserID はユーザーIDで友達数を取得する
+	CountFriendsByUserID(ctx context.Context, userID string) (int, error)
+
+	// CountPendingRequestsByReceiverID は受信者IDで承認待ちリクエスト数を取得する
+	CountPendingRequestsByReceiverID(ctx context.Context, receiverID string) (int, error)
+
+	// CountByStatus はステータスごとの関係数を取得する
+	CountByStatus(ctx context.Context, status valueobject.RelationshipStatus) (int, error)
+
+	// FindAll はすべての友達関係を取得する（ページネーション対応）
+	FindAll(ctx context.Context, offset, limit int) ([]*entity.Relationship, error)
+
+	// Count は総関係数を取得する
+	Count(ctx context.Context) (int, error)
+}

--- a/internal/domain/repository/repository_factory.go
+++ b/internal/domain/repository/repository_factory.go
@@ -1,0 +1,24 @@
+package repository
+
+// RepositoryFactory はすべてのリポジトリを提供するファクトリインターフェース
+type RepositoryFactory interface {
+	// UserRepository はユーザーリポジトリを取得する
+	UserRepository() UserRepository
+
+	// MorningCallRepository はモーニングコールリポジトリを取得する
+	MorningCallRepository() MorningCallRepository
+
+	// RelationshipRepository は友達関係リポジトリを取得する
+	RelationshipRepository() RelationshipRepository
+
+	// TransactionManager はトランザクションマネージャーを取得する
+	TransactionManager() TransactionManager
+}
+
+// Repositories はリポジトリの集合を表す構造体
+type Repositories struct {
+	User         UserRepository
+	MorningCall  MorningCallRepository
+	Relationship RelationshipRepository
+	TxManager    TransactionManager
+}

--- a/internal/domain/repository/transaction_manager.go
+++ b/internal/domain/repository/transaction_manager.go
@@ -1,0 +1,28 @@
+package repository
+
+import "context"
+
+// TransactionManager はトランザクション管理を担うインターフェース
+type TransactionManager interface {
+	// ExecuteInTransaction はトランザクション内で処理を実行する
+	// 処理が成功した場合はコミット、エラーが発生した場合はロールバックする
+	ExecuteInTransaction(ctx context.Context, fn func(ctx context.Context) error) error
+}
+
+// Transaction はトランザクションを表すインターフェース
+type Transaction interface {
+	// Commit はトランザクションをコミットする
+	Commit() error
+
+	// Rollback はトランザクションをロールバックする
+	Rollback() error
+}
+
+// TransactionalRepository はトランザクション対応のリポジトリインターフェース
+type TransactionalRepository interface {
+	// BeginTransaction はトランザクションを開始する
+	BeginTransaction(ctx context.Context) (Transaction, error)
+
+	// WithTransaction は指定されたトランザクションでリポジトリを取得する
+	WithTransaction(tx Transaction) interface{}
+}

--- a/internal/domain/repository/user_repository.go
+++ b/internal/domain/repository/user_repository.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+)
+
+// UserRepository はユーザーエンティティの永続化を担うリポジトリインターフェース
+type UserRepository interface {
+	// Create は新しいユーザーを作成する
+	Create(ctx context.Context, user *entity.User) error
+
+	// FindByID はIDでユーザーを検索する
+	FindByID(ctx context.Context, id string) (*entity.User, error)
+
+	// FindByUsername はユーザー名でユーザーを検索する
+	FindByUsername(ctx context.Context, username string) (*entity.User, error)
+
+	// FindByEmail はメールアドレスでユーザーを検索する
+	FindByEmail(ctx context.Context, email string) (*entity.User, error)
+
+	// Update はユーザー情報を更新する
+	Update(ctx context.Context, user *entity.User) error
+
+	// Delete はユーザーを削除する
+	Delete(ctx context.Context, id string) error
+
+	// ExistsByID はIDでユーザーの存在を確認する
+	ExistsByID(ctx context.Context, id string) (bool, error)
+
+	// ExistsByUsername はユーザー名でユーザーの存在を確認する
+	ExistsByUsername(ctx context.Context, username string) (bool, error)
+
+	// ExistsByEmail はメールアドレスでユーザーの存在を確認する
+	ExistsByEmail(ctx context.Context, email string) (bool, error)
+
+	// FindAll はすべてのユーザーを取得する（ページネーション対応）
+	FindAll(ctx context.Context, offset, limit int) ([]*entity.User, error)
+
+	// Count は総ユーザー数を取得する
+	Count(ctx context.Context) (int, error)
+}


### PR DESCRIPTION
This pull request introduces a set of new repository interfaces and supporting types to the domain layer, laying the foundation for data persistence and transaction management in a clean, modular way. The main changes include defining interfaces for user, morning call, and relationship repositories, standardizing error handling, and introducing transaction management abstractions.

**Repository interface definitions:**

* Added `UserRepository`, `MorningCallRepository`, and `RelationshipRepository` interfaces, each specifying CRUD operations, existence checks, and various query methods tailored to their respective entities. These interfaces will help ensure a clear contract between the domain and infrastructure layers. [[1]](diffhunk://#diff-20270353a4d917a7a9dc3b2504778213a2c8b1dc59cef2508c60b50264dacbc8R1-R43) [[2]](diffhunk://#diff-db1cfdd730857894a80408eca05548603aa6aa34d33fe94eda8d9f91eacf3870R1-R60) [[3]](diffhunk://#diff-9e3f0411a9243620ec7ad7e118bd2bf1ea870e0954f7cb4d2fe7594a75de235fR1-R77)

**Transaction management:**

* Introduced the `TransactionManager`, `Transaction`, and `TransactionalRepository` interfaces in `transaction_manager.go` to support transactional operations, including commit/rollback semantics and executing functions within a transaction scope.

**Repository factory and aggregation:**

* Added the `RepositoryFactory` interface and `Repositories` struct in `repository_factory.go` to provide a centralized way to access all repositories and the transaction manager, improving dependency management and testability.

**Error handling standardization:**

* Defined a set of common repository errors in `errors.go`, such as `ErrNotFound`, `ErrAlreadyExists`, and `ErrTransactionFailed`, to standardize error reporting across repository implementations.