### PR TITLE
feat: implement AuthUseCase with session management

### DIFF
--- a/internal/usecase/auth/auth_usecase.go
+++ b/internal/usecase/auth/auth_usecase.go
@@ -1,0 +1,221 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/repository"
+	"github.com/ochamu/morning-call-api/internal/domain/service"
+)
+
+// Session はユーザーセッション情報を表す
+type Session struct {
+	ID        string
+	UserID    string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// AuthUseCase は認証に関するユースケースを実装する
+type AuthUseCase struct {
+	userRepo        repository.UserRepository
+	passwordService service.PasswordService
+	sessions        map[string]*Session
+	sessionMutex    sync.RWMutex
+	sessionTimeout  time.Duration
+}
+
+// NewAuthUseCase は新しい認証ユースケースを作成する
+func NewAuthUseCase(userRepo repository.UserRepository, passwordService service.PasswordService) *AuthUseCase {
+	return &AuthUseCase{
+		userRepo:        userRepo,
+		passwordService: passwordService,
+		sessions:        make(map[string]*Session),
+		sessionTimeout:  24 * time.Hour, // デフォルトで24時間のセッション有効期限
+	}
+}
+
+// LoginInput はログイン時の入力データ
+type LoginInput struct {
+	Username string
+	Password string
+}
+
+// LoginOutput はログイン時の出力データ
+type LoginOutput struct {
+	SessionID string
+	User      *entity.User
+}
+
+// Login はユーザー名とパスワードで認証を行う
+func (u *AuthUseCase) Login(ctx context.Context, input LoginInput) (*LoginOutput, error) {
+	// 入力値の検証
+	if input.Username == "" {
+		return nil, fmt.Errorf("ユーザー名は必須です")
+	}
+	if input.Password == "" {
+		return nil, fmt.Errorf("パスワードは必須です")
+	}
+
+	// ユーザーを取得
+	user, err := u.userRepo.FindByUsername(ctx, input.Username)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("ユーザー名またはパスワードが間違っています")
+		}
+		return nil, fmt.Errorf("ログイン処理中にエラーが発生しました: %w", err)
+	}
+
+	// パスワードを検証
+	valid, err := u.passwordService.VerifyPassword(input.Password, user.PasswordHash)
+	if err != nil {
+		return nil, fmt.Errorf("パスワード検証中にエラーが発生しました: %w", err)
+	}
+	if !valid {
+		return nil, fmt.Errorf("ユーザー名またはパスワードが間違っています")
+	}
+
+	// セッションを作成
+	sessionID, err := u.createSession(user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("セッション作成に失敗しました: %w", err)
+	}
+
+	return &LoginOutput{
+		SessionID: sessionID,
+		User:      user,
+	}, nil
+}
+
+// Logout はセッションを削除してログアウトする
+func (u *AuthUseCase) Logout(_ context.Context, sessionID string) error {
+	if sessionID == "" {
+		return fmt.Errorf("セッションIDは必須です")
+	}
+
+	u.sessionMutex.Lock()
+	defer u.sessionMutex.Unlock()
+
+	if _, exists := u.sessions[sessionID]; !exists {
+		return fmt.Errorf("無効なセッションです")
+	}
+
+	delete(u.sessions, sessionID)
+	return nil
+}
+
+// GetCurrentUser はセッションIDから現在のユーザー情報を取得する
+func (u *AuthUseCase) GetCurrentUser(ctx context.Context, sessionID string) (*entity.User, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("セッションIDは必須です")
+	}
+
+	// セッションを取得
+	session, err := u.getSession(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// セッションの有効期限を確認
+	if time.Now().After(session.ExpiresAt) {
+		// 期限切れのセッションを削除
+		u.sessionMutex.Lock()
+		delete(u.sessions, sessionID)
+		u.sessionMutex.Unlock()
+		return nil, fmt.Errorf("セッションの有効期限が切れています")
+	}
+
+	// ユーザー情報を取得
+	user, err := u.userRepo.FindByID(ctx, session.UserID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			// ユーザーが削除された場合はセッションも削除
+			u.sessionMutex.Lock()
+			delete(u.sessions, sessionID)
+			u.sessionMutex.Unlock()
+			return nil, fmt.Errorf("ユーザーが見つかりません")
+		}
+		return nil, fmt.Errorf("ユーザー情報の取得に失敗しました: %w", err)
+	}
+
+	return user, nil
+}
+
+// ValidateSession はセッションの有効性を検証する
+func (u *AuthUseCase) ValidateSession(_ context.Context, sessionID string) (bool, error) {
+	if sessionID == "" {
+		return false, nil
+	}
+
+	session, err := u.getSession(sessionID)
+	if err != nil {
+		return false, nil
+	}
+
+	// 有効期限のチェック
+	if time.Now().After(session.ExpiresAt) {
+		// 期限切れのセッションを削除
+		u.sessionMutex.Lock()
+		delete(u.sessions, sessionID)
+		u.sessionMutex.Unlock()
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// createSession は新しいセッションを作成する
+func (u *AuthUseCase) createSession(userID string) (string, error) {
+	// セッションIDを生成
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("セッションID生成に失敗しました: %w", err)
+	}
+	sessionID := hex.EncodeToString(b)
+
+	// セッションを保存
+	u.sessionMutex.Lock()
+	defer u.sessionMutex.Unlock()
+
+	now := time.Now()
+	u.sessions[sessionID] = &Session{
+		ID:        sessionID,
+		UserID:    userID,
+		CreatedAt: now,
+		ExpiresAt: now.Add(u.sessionTimeout),
+	}
+
+	return sessionID, nil
+}
+
+// getSession はセッションを取得する
+func (u *AuthUseCase) getSession(sessionID string) (*Session, error) {
+	u.sessionMutex.RLock()
+	defer u.sessionMutex.RUnlock()
+
+	session, exists := u.sessions[sessionID]
+	if !exists {
+		return nil, fmt.Errorf("セッションが見つかりません")
+	}
+
+	return session, nil
+}
+
+// CleanupExpiredSessions は期限切れのセッションを削除する（定期実行用）
+func (u *AuthUseCase) CleanupExpiredSessions() {
+	u.sessionMutex.Lock()
+	defer u.sessionMutex.Unlock()
+
+	now := time.Now()
+	for id, session := range u.sessions {
+		if now.After(session.ExpiresAt) {
+			delete(u.sessions, id)
+		}
+	}
+}

--- a/internal/usecase/auth/auth_usecase_test.go
+++ b/internal/usecase/auth/auth_usecase_test.go
@@ -1,0 +1,510 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/infrastructure/auth"
+	"github.com/ochamu/morning-call-api/internal/infrastructure/memory"
+)
+
+func TestNewAuthUseCase(t *testing.T) {
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	if uc == nil {
+		t.Fatal("NewAuthUseCase returned nil")
+	}
+	if uc.userRepo == nil {
+		t.Error("userRepo is nil")
+	}
+	if uc.passwordService == nil {
+		t.Error("passwordService is nil")
+	}
+	if uc.sessions == nil {
+		t.Error("sessions map is nil")
+	}
+	if uc.sessionTimeout != 24*time.Hour {
+		t.Errorf("sessionTimeout = %v, want %v", uc.sessionTimeout, 24*time.Hour)
+	}
+}
+
+func TestAuthUseCase_Login(t *testing.T) {
+	ctx := context.Background()
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	// テスト用ユーザーを作成
+	hashedPassword, err := passwordService.HashPassword("password123")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+	testUser := &entity.User{
+		ID:           "user1",
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: hashedPassword,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := userRepo.Create(ctx, testUser); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		input   LoginInput
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "成功ケース",
+			input: LoginInput{
+				Username: "testuser",
+				Password: "password123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "ユーザー名が空",
+			input: LoginInput{
+				Username: "",
+				Password: "password123",
+			},
+			wantErr: true,
+			errMsg:  "ユーザー名は必須です",
+		},
+		{
+			name: "パスワードが空",
+			input: LoginInput{
+				Username: "testuser",
+				Password: "",
+			},
+			wantErr: true,
+			errMsg:  "パスワードは必須です",
+		},
+		{
+			name: "存在しないユーザー",
+			input: LoginInput{
+				Username: "nonexistent",
+				Password: "password123",
+			},
+			wantErr: true,
+			errMsg:  "ユーザー名またはパスワードが間違っています",
+		},
+		{
+			name: "パスワードが間違っている",
+			input: LoginInput{
+				Username: "testuser",
+				Password: "wrongpassword",
+			},
+			wantErr: true,
+			errMsg:  "ユーザー名またはパスワードが間違っています",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := uc.Login(ctx, tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message = %v, want contains %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if output == nil {
+					t.Error("output is nil")
+				} else {
+					if output.SessionID == "" {
+						t.Error("SessionID is empty")
+					}
+					if output.User == nil {
+						t.Error("User is nil")
+					} else if output.User.Username != tt.input.Username {
+						t.Errorf("User.Username = %v, want %v", output.User.Username, tt.input.Username)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAuthUseCase_Logout(t *testing.T) {
+	ctx := context.Background()
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	// テスト用ユーザーとセッションを作成
+	hashedPassword, err := passwordService.HashPassword("password123")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+	testUser := &entity.User{
+		ID:           "user1",
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: hashedPassword,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := userRepo.Create(ctx, testUser); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// ログインしてセッションを作成
+	loginOutput, err := uc.Login(ctx, LoginInput{
+		Username: "testuser",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("failed to login: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		sessionID string
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "成功ケース",
+			sessionID: loginOutput.SessionID,
+			wantErr:   false,
+		},
+		{
+			name:      "セッションIDが空",
+			sessionID: "",
+			wantErr:   true,
+			errMsg:    "セッションIDは必須です",
+		},
+		{
+			name:      "無効なセッション",
+			sessionID: "invalid-session-id",
+			wantErr:   true,
+			errMsg:    "無効なセッションです",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := uc.Logout(ctx, tt.sessionID)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message = %v, want contains %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// ログアウト後はセッションが無効になることを確認
+				if _, err := uc.GetCurrentUser(ctx, tt.sessionID); err == nil {
+					t.Error("expected error after logout but got nil")
+				}
+			}
+		})
+	}
+}
+
+func TestAuthUseCase_GetCurrentUser(t *testing.T) {
+	ctx := context.Background()
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	// テスト用ユーザーを作成
+	hashedPassword, err := passwordService.HashPassword("password123")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+	testUser := &entity.User{
+		ID:           "user1",
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: hashedPassword,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := userRepo.Create(ctx, testUser); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// ログインしてセッションを作成
+	loginOutput, err := uc.Login(ctx, LoginInput{
+		Username: "testuser",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("failed to login: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		sessionID string
+		wantErr   bool
+		errMsg    string
+		wantUser  bool
+	}{
+		{
+			name:      "成功ケース",
+			sessionID: loginOutput.SessionID,
+			wantErr:   false,
+			wantUser:  true,
+		},
+		{
+			name:      "セッションIDが空",
+			sessionID: "",
+			wantErr:   true,
+			errMsg:    "セッションIDは必須です",
+			wantUser:  false,
+		},
+		{
+			name:      "無効なセッション",
+			sessionID: "invalid-session-id",
+			wantErr:   true,
+			errMsg:    "セッションが見つかりません",
+			wantUser:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, err := uc.GetCurrentUser(ctx, tt.sessionID)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message = %v, want contains %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if tt.wantUser {
+					if user == nil {
+						t.Error("user is nil")
+					} else if user.Username != "testuser" {
+						t.Errorf("user.Username = %v, want %v", user.Username, "testuser")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAuthUseCase_GetCurrentUser_ExpiredSession(t *testing.T) {
+	ctx := context.Background()
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	// セッションタイムアウトを短く設定
+	uc.sessionTimeout = 1 * time.Millisecond
+
+	// テスト用ユーザーを作成
+	hashedPassword, err := passwordService.HashPassword("password123")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+	testUser := &entity.User{
+		ID:           "user1",
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: hashedPassword,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := userRepo.Create(ctx, testUser); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// ログインしてセッションを作成
+	loginOutput, err := uc.Login(ctx, LoginInput{
+		Username: "testuser",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("failed to login: %v", err)
+	}
+
+	// セッションの有効期限が切れるまで待つ
+	time.Sleep(2 * time.Millisecond)
+
+	// 期限切れのセッションでユーザー取得を試みる
+	_, err = uc.GetCurrentUser(ctx, loginOutput.SessionID)
+	if err == nil {
+		t.Error("expected error for expired session but got nil")
+	} else if !strings.Contains(err.Error(), "セッションの有効期限が切れています") {
+		t.Errorf("error message = %v, want contains '有効期限が切れています'", err.Error())
+	}
+}
+
+func TestAuthUseCase_ValidateSession(t *testing.T) {
+	ctx := context.Background()
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	// テスト用ユーザーを作成
+	hashedPassword, err := passwordService.HashPassword("password123")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+	testUser := &entity.User{
+		ID:           "user1",
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: hashedPassword,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := userRepo.Create(ctx, testUser); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// ログインしてセッションを作成
+	loginOutput, err := uc.Login(ctx, LoginInput{
+		Username: "testuser",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("failed to login: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		sessionID string
+		want      bool
+	}{
+		{
+			name:      "有効なセッション",
+			sessionID: loginOutput.SessionID,
+			want:      true,
+		},
+		{
+			name:      "セッションIDが空",
+			sessionID: "",
+			want:      false,
+		},
+		{
+			name:      "無効なセッション",
+			sessionID: "invalid-session-id",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, err := uc.ValidateSession(ctx, tt.sessionID)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if valid != tt.want {
+				t.Errorf("ValidateSession() = %v, want %v", valid, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthUseCase_CleanupExpiredSessions(t *testing.T) {
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	// セッションタイムアウトを短く設定
+	uc.sessionTimeout = 1 * time.Millisecond
+
+	// テスト用セッションを作成
+	sessionID1, _ := uc.createSession("user1")
+	sessionID2, _ := uc.createSession("user2")
+
+	// セッションが存在することを確認
+	if len(uc.sessions) != 2 {
+		t.Errorf("sessions count = %d, want 2", len(uc.sessions))
+	}
+
+	// セッションの有効期限が切れるまで待つ
+	time.Sleep(2 * time.Millisecond)
+
+	// 期限切れセッションをクリーンアップ
+	uc.CleanupExpiredSessions()
+
+	// セッションが削除されたことを確認
+	if len(uc.sessions) != 0 {
+		t.Errorf("sessions count = %d, want 0", len(uc.sessions))
+	}
+
+	// 削除されたセッションIDで取得を試みる
+	if _, err := uc.getSession(sessionID1); err == nil {
+		t.Error("expected error for deleted session but got nil")
+	}
+	if _, err := uc.getSession(sessionID2); err == nil {
+		t.Error("expected error for deleted session but got nil")
+	}
+}
+
+func TestAuthUseCase_GetCurrentUser_DeletedUser(t *testing.T) {
+	ctx := context.Background()
+	userRepo := memory.NewUserRepository()
+	passwordService := auth.NewPasswordService()
+	uc := NewAuthUseCase(userRepo, passwordService)
+
+	// テスト用ユーザーを作成
+	hashedPassword, err := passwordService.HashPassword("password123")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+	testUser := &entity.User{
+		ID:           "user1",
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: hashedPassword,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := userRepo.Create(ctx, testUser); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	// ログインしてセッションを作成
+	loginOutput, err := uc.Login(ctx, LoginInput{
+		Username: "testuser",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("failed to login: %v", err)
+	}
+
+	// ユーザーを削除
+	if err := userRepo.Delete(ctx, "user1"); err != nil {
+		t.Fatalf("failed to delete user: %v", err)
+	}
+
+	// 削除されたユーザーでセッションからユーザー取得を試みる
+	_, err = uc.GetCurrentUser(ctx, loginOutput.SessionID)
+	if err == nil {
+		t.Error("expected error for deleted user but got nil")
+	} else if !strings.Contains(err.Error(), "ユーザーが見つかりません") {
+		t.Errorf("error message = %v, want contains 'ユーザーが見つかりません'", err.Error())
+	}
+
+	// セッションも削除されていることを確認
+	if _, err := uc.getSession(loginOutput.SessionID); err == nil {
+		t.Error("expected session to be deleted but it still exists")
+	}
+}


### PR DESCRIPTION
This pull request introduces a new authentication use case implementation in `internal/usecase/auth/auth_usecase.go`. It adds session-based login, logout, session validation, and user retrieval functionality, managing sessions in memory with thread safety and expiration handling.

Authentication and session management:

* Implements the `AuthUseCase` struct with in-memory session management, including mutex protection and session expiration logic.
* Adds methods for logging in (`Login`), logging out (`Logout`), validating sessions (`ValidateSession`), and retrieving the current user by session (`GetCurrentUser`).
* Provides session lifecycle management with secure session ID generation and automatic cleanup of expired sessions via `CleanupExpiredSessions`.

Integration with domain layer:

* Uses `UserRepository` and `PasswordService` interfaces for user lookup and password verification, ensuring separation of concerns and testability.