### PR TITLE
feat: implement MorningCall Delete use case with authorization and st…

### DIFF
--- a/internal/usecase/morning_call/delete.go
+++ b/internal/usecase/morning_call/delete.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
 	"github.com/ochamu/morning-call-api/internal/domain/repository"
 	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
 )
@@ -12,17 +13,14 @@ import (
 // DeleteUseCase はモーニングコール削除のユースケース
 type DeleteUseCase struct {
 	morningCallRepo repository.MorningCallRepository
-	userRepo        repository.UserRepository
 }
 
 // NewDeleteUseCase は新しいモーニングコール削除ユースケースを作成する
 func NewDeleteUseCase(
 	morningCallRepo repository.MorningCallRepository,
-	userRepo repository.UserRepository,
 ) *DeleteUseCase {
 	return &DeleteUseCase{
 		morningCallRepo: morningCallRepo,
-		userRepo:        userRepo,
 	}
 }
 
@@ -32,41 +30,49 @@ type DeleteInput struct {
 	SenderID string // 削除権限確認用
 }
 
+// DeleteOutput はモーニングコール削除の出力データ
+type DeleteOutput struct {
+	DeletedMorningCall *entity.MorningCall // 削除されたモーニングコールの情報
+}
+
 // Execute はモーニングコールを削除する
-func (uc *DeleteUseCase) Execute(ctx context.Context, input DeleteInput) error {
+func (uc *DeleteUseCase) Execute(ctx context.Context, input DeleteInput) (*DeleteOutput, error) {
 	// 入力値の基本検証
 	if input.ID == "" {
-		return fmt.Errorf("モーニングコールIDは必須です")
+		return nil, fmt.Errorf("モーニングコールIDは必須です")
 	}
 	if input.SenderID == "" {
-		return fmt.Errorf("送信者IDは必須です")
+		return nil, fmt.Errorf("送信者IDは必須です")
 	}
 
 	// モーニングコールの存在確認
 	morningCall, err := uc.morningCallRepo.FindByID(ctx, input.ID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return fmt.Errorf("モーニングコールが見つかりません")
+			return nil, fmt.Errorf("モーニングコールが見つかりません")
 		}
-		return fmt.Errorf("モーニングコールの取得中にエラーが発生しました: %w", err)
+		return nil, fmt.Errorf("モーニングコールの取得中にエラーが発生しました: %w", err)
 	}
 
 	// 送信者の確認（送信者のみが削除可能）
 	if morningCall.SenderID != input.SenderID {
-		return fmt.Errorf("送信者のみがモーニングコールを削除できます")
+		return nil, fmt.Errorf("送信者のみがモーニングコールを削除できます")
 	}
 
 	// ステータスの確認（スケジュール済みまたはキャンセル済みのみ削除可能）
 	// 配信済みや確認済みのものは履歴として残す必要があるため削除不可
 	if morningCall.Status != valueobject.MorningCallStatusScheduled &&
 		morningCall.Status != valueobject.MorningCallStatusCancelled {
-		return fmt.Errorf("削除できるのはスケジュール済みまたはキャンセル済みのモーニングコールのみです")
+		return nil, fmt.Errorf("削除できるのはスケジュール済みまたはキャンセル済みのモーニングコールのみです")
 	}
 
 	// リポジトリから削除
 	if err := uc.morningCallRepo.Delete(ctx, input.ID); err != nil {
-		return fmt.Errorf("モーニングコールの削除に失敗しました: %w", err)
+		return nil, fmt.Errorf("モーニングコールの削除に失敗しました: %w", err)
 	}
 
-	return nil
+	// 削除されたモーニングコールの情報を返す
+	return &DeleteOutput{
+		DeletedMorningCall: morningCall,
+	}, nil
 }


### PR DESCRIPTION
This pull request introduces a new use case for deleting morning calls, encapsulating the business logic for validating and performing the deletion. The main changes are the addition of a dedicated `DeleteUseCase` struct and its associated methods, which enforce rules around who can delete a morning call and under what conditions.

**New morning call deletion use case:**

* Added `DeleteUseCase` struct in `internal/usecase/morning_call/delete.go` to handle morning call deletion, including constructor and input validation logic.
* Implemented permission checks to ensure only the sender can delete a morning call, and only if the call is scheduled or cancelled (not delivered or confirmed).
* Integrated repository interactions for fetching and deleting morning calls, with error handling for not found and other repository errors.