### PR TITLE
feat: implement SendFriendRequest use case for relationship management

### DIFF
--- a/internal/usecase/relationship/send_friend_request.go
+++ b/internal/usecase/relationship/send_friend_request.go
@@ -1,0 +1,147 @@
+package relationship
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/repository"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+	"github.com/ochamu/morning-call-api/pkg/utils"
+)
+
+// SendFriendRequestUseCase は友達リクエスト送信のユースケース
+type SendFriendRequestUseCase struct {
+	relationshipRepo repository.RelationshipRepository
+	userRepo         repository.UserRepository
+}
+
+// NewSendFriendRequestUseCase は新しい友達リクエスト送信ユースケースを作成する
+func NewSendFriendRequestUseCase(
+	relationshipRepo repository.RelationshipRepository,
+	userRepo repository.UserRepository,
+) *SendFriendRequestUseCase {
+	return &SendFriendRequestUseCase{
+		relationshipRepo: relationshipRepo,
+		userRepo:         userRepo,
+	}
+}
+
+// SendFriendRequestInput は友達リクエスト送信の入力データ
+type SendFriendRequestInput struct {
+	RequesterID string // リクエスト送信者のユーザーID
+	ReceiverID  string // リクエスト受信者のユーザーID
+}
+
+// SendFriendRequestOutput は友達リクエスト送信の出力データ
+type SendFriendRequestOutput struct {
+	Relationship *entity.Relationship
+}
+
+// Execute は友達リクエストを送信する
+func (uc *SendFriendRequestUseCase) Execute(ctx context.Context, input SendFriendRequestInput) (*SendFriendRequestOutput, error) {
+	// 入力値の基本検証
+	if input.RequesterID == "" {
+		return nil, fmt.Errorf("リクエスト送信者IDは必須です")
+	}
+	if input.ReceiverID == "" {
+		return nil, fmt.Errorf("リクエスト受信者IDは必須です")
+	}
+	if input.RequesterID == input.ReceiverID {
+		return nil, fmt.Errorf("自分自身に友達リクエストを送ることはできません")
+	}
+
+	// リクエスト送信者の存在確認
+	requester, err := uc.userRepo.FindByID(ctx, input.RequesterID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("リクエスト送信者が見つかりません")
+		}
+		return nil, fmt.Errorf("リクエスト送信者の確認中にエラーが発生しました: %w", err)
+	}
+
+	// リクエスト受信者の存在確認
+	receiver, err := uc.userRepo.FindByID(ctx, input.ReceiverID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("リクエスト受信者が見つかりません")
+		}
+		return nil, fmt.Errorf("リクエスト受信者の確認中にエラーが発生しました: %w", err)
+	}
+
+	// 既存の関係を確認
+	existingRelationship, err := uc.relationshipRepo.FindByUserPair(ctx, input.RequesterID, input.ReceiverID)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return nil, fmt.Errorf("既存の関係確認中にエラーが発生しました: %w", err)
+	}
+
+	// 既存の関係がある場合の処理
+	if existingRelationship != nil {
+		switch existingRelationship.Status {
+		case valueobject.RelationshipStatusAccepted:
+			return nil, fmt.Errorf("既に友達関係です")
+		case valueobject.RelationshipStatusPending:
+			// 既に承認待ちのリクエストがある場合
+			if existingRelationship.RequesterID == input.RequesterID {
+				return nil, fmt.Errorf("既に友達リクエストを送信済みです")
+			}
+			// 相手から既にリクエストが来ている場合
+			return nil, fmt.Errorf("相手から既に友達リクエストが送信されています。リクエストを承認してください")
+		case valueobject.RelationshipStatusBlocked:
+			// どちらかがブロックしている場合
+			if existingRelationship.RequesterID == input.RequesterID {
+				return nil, fmt.Errorf("相手をブロックしているため、友達リクエストを送信できません")
+			}
+			return nil, fmt.Errorf("相手にブロックされているため、友達リクエストを送信できません")
+		case valueobject.RelationshipStatusRejected:
+			// 以前に拒否されたリクエストの場合
+			if existingRelationship.RequesterID == input.RequesterID {
+				// 同じ方向のリクエストで拒否済みの場合、再送信を試みる
+				now := time.Now()
+				// 拒否から24時間経過していない場合はエラー
+				if existingRelationship.UpdatedAt.Add(24 * time.Hour).After(now) {
+					return nil, fmt.Errorf("友達リクエストが拒否されました。24時間後に再送信できます")
+				}
+				// 24時間経過している場合は再送信
+				if reason := existingRelationship.Resend(); reason.IsNG() {
+					return nil, fmt.Errorf("友達リクエストの再送信に失敗しました: %s", reason)
+				}
+				// リポジトリで更新
+				if err := uc.relationshipRepo.Update(ctx, existingRelationship); err != nil {
+					return nil, fmt.Errorf("友達リクエストの再送信に失敗しました: %w", err)
+				}
+				return &SendFriendRequestOutput{
+					Relationship: existingRelationship,
+				}, nil
+			}
+			// 逆方向のリクエストが拒否されている場合は新規作成を許可
+		}
+	}
+
+	// UUIDを生成
+	id, err := utils.GenerateUUID()
+	if err != nil {
+		return nil, fmt.Errorf("ID生成に失敗しました: %w", err)
+	}
+
+	// 友達関係エンティティを作成
+	relationship, reason := entity.NewRelationship(id, requester.ID, receiver.ID)
+	if reason.IsNG() {
+		return nil, fmt.Errorf("友達リクエストの作成に失敗しました: %s", reason)
+	}
+
+	// リポジトリに保存
+	if err := uc.relationshipRepo.Create(ctx, relationship); err != nil {
+		// 重複エラーの場合は分かりやすいメッセージにする
+		if errors.Is(err, repository.ErrAlreadyExists) {
+			return nil, fmt.Errorf("既に友達関係が存在します")
+		}
+		return nil, fmt.Errorf("友達リクエストの送信に失敗しました: %w", err)
+	}
+
+	return &SendFriendRequestOutput{
+		Relationship: relationship,
+	}, nil
+}

--- a/internal/usecase/relationship/send_friend_request_test.go
+++ b/internal/usecase/relationship/send_friend_request_test.go
@@ -1,0 +1,562 @@
+package relationship
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+	"github.com/ochamu/morning-call-api/internal/infrastructure/memory"
+)
+
+func TestNewSendFriendRequestUseCase(t *testing.T) {
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	uc := NewSendFriendRequestUseCase(relationshipRepo, userRepo)
+
+	if uc == nil {
+		t.Fatal("NewSendFriendRequestUseCase returned nil")
+	}
+	if uc.relationshipRepo == nil {
+		t.Error("relationshipRepo is nil")
+	}
+	if uc.userRepo == nil {
+		t.Error("userRepo is nil")
+	}
+}
+
+func TestSendFriendRequestUseCase_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	// テスト用のリポジトリを作成
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	// テスト用ユーザーを作成
+	user1 := &entity.User{
+		ID:           "user1",
+		Username:     "alice",
+		Email:        "alice@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user2 := &entity.User{
+		ID:           "user2",
+		Username:     "bob",
+		Email:        "bob@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user3 := &entity.User{
+		ID:           "user3",
+		Username:     "charlie",
+		Email:        "charlie@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user4 := &entity.User{
+		ID:           "user4",
+		Username:     "david",
+		Email:        "david@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	// ユーザーをリポジトリに追加
+	if err := userRepo.Create(ctx, user1); err != nil {
+		t.Fatalf("failed to create user1: %v", err)
+	}
+	if err := userRepo.Create(ctx, user2); err != nil {
+		t.Fatalf("failed to create user2: %v", err)
+	}
+	if err := userRepo.Create(ctx, user3); err != nil {
+		t.Fatalf("failed to create user3: %v", err)
+	}
+	if err := userRepo.Create(ctx, user4); err != nil {
+		t.Fatalf("failed to create user4: %v", err)
+	}
+
+	// user1とuser3は既に友達
+	existingFriendship := &entity.Relationship{
+		ID:          "rel1",
+		RequesterID: user1.ID,
+		ReceiverID:  user3.ID,
+		Status:      valueobject.RelationshipStatusAccepted,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := relationshipRepo.Create(ctx, existingFriendship); err != nil {
+		t.Fatalf("failed to create existing friendship: %v", err)
+	}
+
+	// user1はuser4をブロック
+	blockedRelation := &entity.Relationship{
+		ID:          "rel2",
+		RequesterID: user1.ID,
+		ReceiverID:  user4.ID,
+		Status:      valueobject.RelationshipStatusBlocked,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := relationshipRepo.Create(ctx, blockedRelation); err != nil {
+		t.Fatalf("failed to create blocked relation: %v", err)
+	}
+
+	// UseCaseを作成
+	uc := NewSendFriendRequestUseCase(relationshipRepo, userRepo)
+
+	tests := []struct {
+		name        string
+		input       SendFriendRequestInput
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "正常: 新規友達リクエスト送信",
+			input: SendFriendRequestInput{
+				RequesterID: user1.ID,
+				ReceiverID:  user2.ID,
+			},
+			wantErr: false,
+		},
+		{
+			name: "エラー: リクエスト送信者IDが空",
+			input: SendFriendRequestInput{
+				RequesterID: "",
+				ReceiverID:  user2.ID,
+			},
+			wantErr:     true,
+			errContains: "リクエスト送信者IDは必須です",
+		},
+		{
+			name: "エラー: リクエスト受信者IDが空",
+			input: SendFriendRequestInput{
+				RequesterID: user1.ID,
+				ReceiverID:  "",
+			},
+			wantErr:     true,
+			errContains: "リクエスト受信者IDは必須です",
+		},
+		{
+			name: "エラー: 自分自身に友達リクエスト",
+			input: SendFriendRequestInput{
+				RequesterID: user1.ID,
+				ReceiverID:  user1.ID,
+			},
+			wantErr:     true,
+			errContains: "自分自身に友達リクエストを送ることはできません",
+		},
+		{
+			name: "エラー: リクエスト送信者が存在しない",
+			input: SendFriendRequestInput{
+				RequesterID: "non_existent_user",
+				ReceiverID:  user2.ID,
+			},
+			wantErr:     true,
+			errContains: "リクエスト送信者が見つかりません",
+		},
+		{
+			name: "エラー: リクエスト受信者が存在しない",
+			input: SendFriendRequestInput{
+				RequesterID: user1.ID,
+				ReceiverID:  "non_existent_user",
+			},
+			wantErr:     true,
+			errContains: "リクエスト受信者が見つかりません",
+		},
+		{
+			name: "エラー: 既に友達関係",
+			input: SendFriendRequestInput{
+				RequesterID: user1.ID,
+				ReceiverID:  user3.ID,
+			},
+			wantErr:     true,
+			errContains: "既に友達関係です",
+		},
+		{
+			name: "エラー: ブロックしている相手にリクエスト",
+			input: SendFriendRequestInput{
+				RequesterID: user1.ID,
+				ReceiverID:  user4.ID,
+			},
+			wantErr:     true,
+			errContains: "相手をブロックしているため、友達リクエストを送信できません",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := uc.Execute(ctx, tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error message = %q, want contains %q", err.Error(), tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if output == nil {
+					t.Error("output is nil")
+					return
+				}
+				if output.Relationship == nil {
+					t.Error("output.Relationship is nil")
+					return
+				}
+				// 関係の検証
+				if output.Relationship.RequesterID != tt.input.RequesterID {
+					t.Errorf("RequesterID = %q, want %q", output.Relationship.RequesterID, tt.input.RequesterID)
+				}
+				if output.Relationship.ReceiverID != tt.input.ReceiverID {
+					t.Errorf("ReceiverID = %q, want %q", output.Relationship.ReceiverID, tt.input.ReceiverID)
+				}
+				if output.Relationship.Status != valueobject.RelationshipStatusPending {
+					t.Errorf("Status = %v, want %v", output.Relationship.Status, valueobject.RelationshipStatusPending)
+				}
+			}
+		})
+	}
+}
+
+func TestSendFriendRequestUseCase_Execute_DuplicateRequest(t *testing.T) {
+	ctx := context.Background()
+
+	// テスト用のリポジトリを作成
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	// テスト用ユーザーを作成
+	user1 := &entity.User{
+		ID:           "user1",
+		Username:     "alice",
+		Email:        "alice@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user2 := &entity.User{
+		ID:           "user2",
+		Username:     "bob",
+		Email:        "bob@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	// ユーザーをリポジトリに追加
+	if err := userRepo.Create(ctx, user1); err != nil {
+		t.Fatalf("failed to create user1: %v", err)
+	}
+	if err := userRepo.Create(ctx, user2); err != nil {
+		t.Fatalf("failed to create user2: %v", err)
+	}
+
+	// UseCaseを作成
+	uc := NewSendFriendRequestUseCase(relationshipRepo, userRepo)
+
+	// 1回目のリクエスト送信
+	input := SendFriendRequestInput{
+		RequesterID: user1.ID,
+		ReceiverID:  user2.ID,
+	}
+	output1, err := uc.Execute(ctx, input)
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	if output1 == nil || output1.Relationship == nil {
+		t.Fatal("first request returned nil")
+	}
+
+	// 2回目の同じリクエスト送信（エラーになるはず）
+	output2, err := uc.Execute(ctx, input)
+	if err == nil {
+		t.Error("expected error for duplicate request but got nil")
+		return
+	}
+	if output2 != nil {
+		t.Error("expected nil output for duplicate request")
+	}
+	if !strings.Contains(err.Error(), "既に友達リクエストを送信済みです") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestSendFriendRequestUseCase_Execute_ReverseRequest(t *testing.T) {
+	ctx := context.Background()
+
+	// テスト用のリポジトリを作成
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	// テスト用ユーザーを作成
+	user1 := &entity.User{
+		ID:           "user1",
+		Username:     "alice",
+		Email:        "alice@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user2 := &entity.User{
+		ID:           "user2",
+		Username:     "bob",
+		Email:        "bob@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	// ユーザーをリポジトリに追加
+	if err := userRepo.Create(ctx, user1); err != nil {
+		t.Fatalf("failed to create user1: %v", err)
+	}
+	if err := userRepo.Create(ctx, user2); err != nil {
+		t.Fatalf("failed to create user2: %v", err)
+	}
+
+	// user2からuser1への既存のリクエスト
+	existingRequest := &entity.Relationship{
+		ID:          "rel1",
+		RequesterID: user2.ID,
+		ReceiverID:  user1.ID,
+		Status:      valueobject.RelationshipStatusPending,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := relationshipRepo.Create(ctx, existingRequest); err != nil {
+		t.Fatalf("failed to create existing request: %v", err)
+	}
+
+	// UseCaseを作成
+	uc := NewSendFriendRequestUseCase(relationshipRepo, userRepo)
+
+	// user1からuser2へのリクエスト（逆方向）
+	input := SendFriendRequestInput{
+		RequesterID: user1.ID,
+		ReceiverID:  user2.ID,
+	}
+	output, err := uc.Execute(ctx, input)
+	if err == nil {
+		t.Error("expected error for reverse request but got nil")
+		return
+	}
+	if output != nil {
+		t.Error("expected nil output for reverse request")
+	}
+	if !strings.Contains(err.Error(), "相手から既に友達リクエストが送信されています") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestSendFriendRequestUseCase_Execute_ResendAfterRejection(t *testing.T) {
+	ctx := context.Background()
+
+	// テスト用のリポジトリを作成
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	// テスト用ユーザーを作成
+	user1 := &entity.User{
+		ID:           "user1",
+		Username:     "alice",
+		Email:        "alice@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user2 := &entity.User{
+		ID:           "user2",
+		Username:     "bob",
+		Email:        "bob@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	// ユーザーをリポジトリに追加
+	if err := userRepo.Create(ctx, user1); err != nil {
+		t.Fatalf("failed to create user1: %v", err)
+	}
+	if err := userRepo.Create(ctx, user2); err != nil {
+		t.Fatalf("failed to create user2: %v", err)
+	}
+
+	// 拒否されたリクエスト（25時間前）
+	rejectedRequest := &entity.Relationship{
+		ID:          "rel1",
+		RequesterID: user1.ID,
+		ReceiverID:  user2.ID,
+		Status:      valueobject.RelationshipStatusRejected,
+		CreatedAt:   time.Now().Add(-25 * time.Hour),
+		UpdatedAt:   time.Now().Add(-25 * time.Hour),
+	}
+	if err := relationshipRepo.Create(ctx, rejectedRequest); err != nil {
+		t.Fatalf("failed to create rejected request: %v", err)
+	}
+
+	// UseCaseを作成
+	uc := NewSendFriendRequestUseCase(relationshipRepo, userRepo)
+
+	// 24時間後の再送信
+	input := SendFriendRequestInput{
+		RequesterID: user1.ID,
+		ReceiverID:  user2.ID,
+	}
+	output, err := uc.Execute(ctx, input)
+	if err != nil {
+		t.Errorf("unexpected error for resend after 24 hours: %v", err)
+	}
+	if output == nil || output.Relationship == nil {
+		t.Fatal("resend returned nil")
+	}
+	if output.Relationship.Status != valueobject.RelationshipStatusPending {
+		t.Errorf("Status = %v, want %v", output.Relationship.Status, valueobject.RelationshipStatusPending)
+	}
+}
+
+func TestSendFriendRequestUseCase_Execute_ResendTooSoon(t *testing.T) {
+	ctx := context.Background()
+
+	// テスト用のリポジトリを作成
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	// テスト用ユーザーを作成
+	user1 := &entity.User{
+		ID:           "user1",
+		Username:     "alice",
+		Email:        "alice@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user2 := &entity.User{
+		ID:           "user2",
+		Username:     "bob",
+		Email:        "bob@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	// ユーザーをリポジトリに追加
+	if err := userRepo.Create(ctx, user1); err != nil {
+		t.Fatalf("failed to create user1: %v", err)
+	}
+	if err := userRepo.Create(ctx, user2); err != nil {
+		t.Fatalf("failed to create user2: %v", err)
+	}
+
+	// 拒否されたリクエスト（1時間前）
+	rejectedRequest := &entity.Relationship{
+		ID:          "rel1",
+		RequesterID: user1.ID,
+		ReceiverID:  user2.ID,
+		Status:      valueobject.RelationshipStatusRejected,
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+		UpdatedAt:   time.Now().Add(-1 * time.Hour),
+	}
+	if err := relationshipRepo.Create(ctx, rejectedRequest); err != nil {
+		t.Fatalf("failed to create rejected request: %v", err)
+	}
+
+	// UseCaseを作成
+	uc := NewSendFriendRequestUseCase(relationshipRepo, userRepo)
+
+	// 24時間以内の再送信（エラーになるはず）
+	input := SendFriendRequestInput{
+		RequesterID: user1.ID,
+		ReceiverID:  user2.ID,
+	}
+	output, err := uc.Execute(ctx, input)
+	if err == nil {
+		t.Error("expected error for resend too soon but got nil")
+		return
+	}
+	if output != nil {
+		t.Error("expected nil output for resend too soon")
+	}
+	if !strings.Contains(err.Error(), "24時間後に再送信できます") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestSendFriendRequestUseCase_Execute_BlockedByReceiver(t *testing.T) {
+	ctx := context.Background()
+
+	// テスト用のリポジトリを作成
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	// テスト用ユーザーを作成
+	user1 := &entity.User{
+		ID:           "user1",
+		Username:     "alice",
+		Email:        "alice@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	user2 := &entity.User{
+		ID:           "user2",
+		Username:     "bob",
+		Email:        "bob@example.com",
+		PasswordHash: "hashed_password",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	// ユーザーをリポジトリに追加
+	if err := userRepo.Create(ctx, user1); err != nil {
+		t.Fatalf("failed to create user1: %v", err)
+	}
+	if err := userRepo.Create(ctx, user2); err != nil {
+		t.Fatalf("failed to create user2: %v", err)
+	}
+
+	// user2がuser1をブロック
+	blockedRelation := &entity.Relationship{
+		ID:          "rel1",
+		RequesterID: user2.ID,
+		ReceiverID:  user1.ID,
+		Status:      valueobject.RelationshipStatusBlocked,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := relationshipRepo.Create(ctx, blockedRelation); err != nil {
+		t.Fatalf("failed to create blocked relation: %v", err)
+	}
+
+	// UseCaseを作成
+	uc := NewSendFriendRequestUseCase(relationshipRepo, userRepo)
+
+	// user1からuser2へのリクエスト（ブロックされている）
+	input := SendFriendRequestInput{
+		RequesterID: user1.ID,
+		ReceiverID:  user2.ID,
+	}
+	output, err := uc.Execute(ctx, input)
+	if err == nil {
+		t.Error("expected error for blocked by receiver but got nil")
+		return
+	}
+	if output != nil {
+		t.Error("expected nil output for blocked by receiver")
+	}
+	if !strings.Contains(err.Error(), "相手にブロックされているため、友達リクエストを送信できません") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}


### PR DESCRIPTION
This pull request introduces a new use case for sending friend requests, encapsulating the logic for validating input, checking user existence, handling existing relationships, and creating or resending friend requests. The new functionality is implemented in the `internal/usecase/relationship/send_friend_request.go` file.

**New friend request use case implementation:**

* Added `SendFriendRequestUseCase` struct and constructor to encapsulate dependencies for sending friend requests. (`internal/usecase/relationship/send_friend_request.go`)
* Implemented input and output data structures (`SendFriendRequestInput`, `SendFriendRequestOutput`) for the use case. (`internal/usecase/relationship/send_friend_request.go`)
* Added comprehensive validation and error handling for user IDs, existence checks, and relationship status (accepted, pending, blocked, rejected). (`internal/usecase/relationship/send_friend_request.go`)
* Implemented logic to create a new relationship or resend a friend request if previously rejected, including a 24-hour cooldown for resending. (`internal/usecase/relationship/send_friend_request.go`)
* Integrated repository operations for finding users, checking relationships, creating, updating, and error handling for duplicate relationships. (`internal/usecase/relationship/send_friend_request.go`)