### PR TITLE
feat: implement RejectFriendRequest use case for relationship management

### DIFF
--- a/internal/usecase/relationship/reject_friend_request.go
+++ b/internal/usecase/relationship/reject_friend_request.go
@@ -1,0 +1,120 @@
+package relationship
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/repository"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+)
+
+// RejectFriendRequestUseCase は友達リクエスト拒否のユースケース
+type RejectFriendRequestUseCase struct {
+	relationshipRepo repository.RelationshipRepository
+	userRepo         repository.UserRepository
+}
+
+// NewRejectFriendRequestUseCase は新しい友達リクエスト拒否ユースケースを作成する
+func NewRejectFriendRequestUseCase(
+	relationshipRepo repository.RelationshipRepository,
+	userRepo repository.UserRepository,
+) *RejectFriendRequestUseCase {
+	return &RejectFriendRequestUseCase{
+		relationshipRepo: relationshipRepo,
+		userRepo:         userRepo,
+	}
+}
+
+// RejectFriendRequestInput は友達リクエスト拒否の入力データ
+type RejectFriendRequestInput struct {
+	RelationshipID string // 拒否する関係ID
+	ReceiverID     string // リクエスト受信者のユーザーID（拒否者）
+}
+
+// RejectFriendRequestOutput は友達リクエスト拒否の出力データ
+type RejectFriendRequestOutput struct {
+	Relationship *entity.Relationship
+}
+
+// Execute は友達リクエストを拒否する
+func (uc *RejectFriendRequestUseCase) Execute(ctx context.Context, input RejectFriendRequestInput) (*RejectFriendRequestOutput, error) {
+	// 入力値の基本検証
+	if input.RelationshipID == "" {
+		return nil, fmt.Errorf("関係IDは必須です")
+	}
+	if input.ReceiverID == "" {
+		return nil, fmt.Errorf("拒否者IDは必須です")
+	}
+
+	// 拒否者の存在確認
+	receiver, err := uc.userRepo.FindByID(ctx, input.ReceiverID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("拒否者が見つかりません")
+		}
+		return nil, fmt.Errorf("拒否者の確認中にエラーが発生しました: %w", err)
+	}
+
+	// 関係の取得
+	relationship, err := uc.relationshipRepo.FindByID(ctx, input.RelationshipID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("友達リクエストが見つかりません")
+		}
+		return nil, fmt.Errorf("友達リクエストの取得中にエラーが発生しました: %w", err)
+	}
+
+	// 拒否権限の確認（リクエスト受信者のみが拒否可能）
+	if relationship.ReceiverID != receiver.ID {
+		return nil, fmt.Errorf("このリクエストを拒否する権限がありません")
+	}
+
+	// ステータスの確認
+	switch relationship.Status {
+	case valueobject.RelationshipStatusAccepted:
+		return nil, fmt.Errorf("既に承認済みの友達リクエストは拒否できません")
+	case valueobject.RelationshipStatusRejected:
+		return nil, fmt.Errorf("既に拒否済みの友達リクエストです")
+	case valueobject.RelationshipStatusBlocked:
+		return nil, fmt.Errorf("ブロック関係のリクエストは拒否できません")
+	case valueobject.RelationshipStatusPending:
+		// 正常なケース - 拒否処理を続行
+	default:
+		return nil, fmt.Errorf("不正なステータスの友達リクエストです")
+	}
+
+	// リクエスト送信者の存在確認（データ整合性のため）
+	requester, err := uc.userRepo.FindByID(ctx, relationship.RequesterID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("リクエスト送信者が見つかりません")
+		}
+		return nil, fmt.Errorf("リクエスト送信者の確認中にエラーが発生しました: %w", err)
+	}
+
+	// 拒否処理を実行
+	if reason := relationship.Reject(); reason.IsNG() {
+		return nil, fmt.Errorf("友達リクエストの拒否に失敗しました: %s", reason)
+	}
+
+	// 更新日時を設定
+	relationship.UpdatedAt = time.Now()
+
+	// リポジトリで更新
+	if err := uc.relationshipRepo.Update(ctx, relationship); err != nil {
+		return nil, fmt.Errorf("友達リクエストの拒否に失敗しました: %w", err)
+	}
+
+	// ログ出力（システムイベント）
+	// 実際の実装では、ここで通知サービスを呼び出して
+	// リクエスト送信者に拒否通知を送ることも考えられる
+	// ただし、拒否の場合は通知しないという選択肢もある
+	_ = requester // リクエスト送信者への通知用（将来の拡張用）
+
+	return &RejectFriendRequestOutput{
+		Relationship: relationship,
+	}, nil
+}

--- a/internal/usecase/relationship/reject_friend_request_test.go
+++ b/internal/usecase/relationship/reject_friend_request_test.go
@@ -1,0 +1,484 @@
+package relationship
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+	"github.com/ochamu/morning-call-api/internal/infrastructure/memory"
+)
+
+func TestNewRejectFriendRequestUseCase(t *testing.T) {
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	uc := NewRejectFriendRequestUseCase(relationshipRepo, userRepo)
+
+	if uc == nil {
+		t.Fatal("NewRejectFriendRequestUseCase returned nil")
+	}
+	if uc.relationshipRepo == nil {
+		t.Error("relationshipRepo is nil")
+	}
+	if uc.userRepo == nil {
+		t.Error("userRepo is nil")
+	}
+}
+
+func TestRejectFriendRequestUseCase_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		setup     func(*testing.T, *memory.RelationshipRepository, *memory.UserRepository)
+		input     RejectFriendRequestInput
+		wantErr   bool
+		errMsg    string
+		checkFunc func(*testing.T, *RejectFriendRequestOutput)
+	}{
+		{
+			name: "成功ケース - Pending状態のリクエストを拒否",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				// ユーザーを作成
+				requester := &entity.User{
+					ID:           "requester1",
+					Username:     "alice",
+					Email:        "alice@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				receiver := &entity.User{
+					ID:           "receiver1",
+					Username:     "bob",
+					Email:        "bob@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				if err := ur.Create(ctx, requester); err != nil {
+					t.Fatalf("failed to create requester: %v", err)
+				}
+				if err := ur.Create(ctx, receiver); err != nil {
+					t.Fatalf("failed to create receiver: %v", err)
+				}
+
+				// Pending状態の関係を作成
+				relationship := &entity.Relationship{
+					ID:          "rel1",
+					RequesterID: requester.ID,
+					ReceiverID:  receiver.ID,
+					Status:      valueobject.RelationshipStatusPending,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, relationship); err != nil {
+					t.Fatalf("failed to create relationship: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "receiver1",
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RejectFriendRequestOutput) {
+				if output == nil {
+					t.Fatal("output is nil")
+				}
+				if output.Relationship == nil {
+					t.Fatal("Relationship is nil")
+				}
+				if output.Relationship.Status != valueobject.RelationshipStatusRejected {
+					t.Errorf("Status = %v, want %v", output.Relationship.Status, valueobject.RelationshipStatusRejected)
+				}
+			},
+		},
+		{
+			name:  "エラー - 関係IDが空",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {},
+			input: RejectFriendRequestInput{
+				RelationshipID: "",
+				ReceiverID:     "receiver1",
+			},
+			wantErr: true,
+			errMsg:  "関係IDは必須です",
+		},
+		{
+			name:  "エラー - 拒否者IDが空",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "",
+			},
+			wantErr: true,
+			errMsg:  "拒否者IDは必須です",
+		},
+		{
+			name: "エラー - 拒否者が存在しない",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				relationship := &entity.Relationship{
+					ID:          "rel1",
+					RequesterID: "requester1",
+					ReceiverID:  "receiver1",
+					Status:      valueobject.RelationshipStatusPending,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, relationship); err != nil {
+					t.Fatalf("failed to create relationship: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "nonexistent",
+			},
+			wantErr: true,
+			errMsg:  "拒否者が見つかりません",
+		},
+		{
+			name: "エラー - 関係が存在しない",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				receiver := &entity.User{
+					ID:           "receiver1",
+					Username:     "bob",
+					Email:        "bob@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				if err := ur.Create(ctx, receiver); err != nil {
+					t.Fatalf("failed to create receiver: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "nonexistent",
+				ReceiverID:     "receiver1",
+			},
+			wantErr: true,
+			errMsg:  "友達リクエストが見つかりません",
+		},
+		{
+			name: "エラー - 拒否権限がない（リクエスト送信者が拒否しようとする）",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				requester := &entity.User{
+					ID:           "requester1",
+					Username:     "alice",
+					Email:        "alice@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				receiver := &entity.User{
+					ID:           "receiver1",
+					Username:     "bob",
+					Email:        "bob@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				if err := ur.Create(ctx, requester); err != nil {
+					t.Fatalf("failed to create requester: %v", err)
+				}
+				if err := ur.Create(ctx, receiver); err != nil {
+					t.Fatalf("failed to create receiver: %v", err)
+				}
+
+				relationship := &entity.Relationship{
+					ID:          "rel1",
+					RequesterID: requester.ID,
+					ReceiverID:  receiver.ID,
+					Status:      valueobject.RelationshipStatusPending,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, relationship); err != nil {
+					t.Fatalf("failed to create relationship: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "requester1", // 送信者が拒否しようとしている
+			},
+			wantErr: true,
+			errMsg:  "このリクエストを拒否する権限がありません",
+		},
+		{
+			name: "エラー - 既に承認済みのリクエスト",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				requester := &entity.User{
+					ID:           "requester1",
+					Username:     "alice",
+					Email:        "alice@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				receiver := &entity.User{
+					ID:           "receiver1",
+					Username:     "bob",
+					Email:        "bob@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				if err := ur.Create(ctx, requester); err != nil {
+					t.Fatalf("failed to create requester: %v", err)
+				}
+				if err := ur.Create(ctx, receiver); err != nil {
+					t.Fatalf("failed to create receiver: %v", err)
+				}
+
+				relationship := &entity.Relationship{
+					ID:          "rel1",
+					RequesterID: requester.ID,
+					ReceiverID:  receiver.ID,
+					Status:      valueobject.RelationshipStatusAccepted,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, relationship); err != nil {
+					t.Fatalf("failed to create relationship: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "receiver1",
+			},
+			wantErr: true,
+			errMsg:  "既に承認済みの友達リクエストは拒否できません",
+		},
+		{
+			name: "エラー - 既に拒否済みのリクエスト",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				requester := &entity.User{
+					ID:           "requester1",
+					Username:     "alice",
+					Email:        "alice@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				receiver := &entity.User{
+					ID:           "receiver1",
+					Username:     "bob",
+					Email:        "bob@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				if err := ur.Create(ctx, requester); err != nil {
+					t.Fatalf("failed to create requester: %v", err)
+				}
+				if err := ur.Create(ctx, receiver); err != nil {
+					t.Fatalf("failed to create receiver: %v", err)
+				}
+
+				relationship := &entity.Relationship{
+					ID:          "rel1",
+					RequesterID: requester.ID,
+					ReceiverID:  receiver.ID,
+					Status:      valueobject.RelationshipStatusRejected,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, relationship); err != nil {
+					t.Fatalf("failed to create relationship: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "receiver1",
+			},
+			wantErr: true,
+			errMsg:  "既に拒否済みの友達リクエストです",
+		},
+		{
+			name: "エラー - ブロック関係のリクエスト",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				requester := &entity.User{
+					ID:           "requester1",
+					Username:     "alice",
+					Email:        "alice@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				receiver := &entity.User{
+					ID:           "receiver1",
+					Username:     "bob",
+					Email:        "bob@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				if err := ur.Create(ctx, requester); err != nil {
+					t.Fatalf("failed to create requester: %v", err)
+				}
+				if err := ur.Create(ctx, receiver); err != nil {
+					t.Fatalf("failed to create receiver: %v", err)
+				}
+
+				relationship := &entity.Relationship{
+					ID:          "rel1",
+					RequesterID: requester.ID,
+					ReceiverID:  receiver.ID,
+					Status:      valueobject.RelationshipStatusBlocked,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, relationship); err != nil {
+					t.Fatalf("failed to create relationship: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "receiver1",
+			},
+			wantErr: true,
+			errMsg:  "ブロック関係のリクエストは拒否できません",
+		},
+		{
+			name: "エラー - リクエスト送信者が存在しない（データ不整合）",
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				receiver := &entity.User{
+					ID:           "receiver1",
+					Username:     "bob",
+					Email:        "bob@example.com",
+					PasswordHash: "hash",
+					CreatedAt:    time.Now(),
+					UpdatedAt:    time.Now(),
+				}
+				if err := ur.Create(ctx, receiver); err != nil {
+					t.Fatalf("failed to create receiver: %v", err)
+				}
+
+				// 存在しない送信者IDで関係を作成（データ不整合の状態）
+				relationship := &entity.Relationship{
+					ID:          "rel1",
+					RequesterID: "nonexistent_requester",
+					ReceiverID:  receiver.ID,
+					Status:      valueobject.RelationshipStatusPending,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, relationship); err != nil {
+					t.Fatalf("failed to create relationship: %v", err)
+				}
+			},
+			input: RejectFriendRequestInput{
+				RelationshipID: "rel1",
+				ReceiverID:     "receiver1",
+			},
+			wantErr: true,
+			errMsg:  "リクエスト送信者が見つかりません",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// リポジトリの初期化
+			relationshipRepo := memory.NewRelationshipRepository()
+			userRepo := memory.NewUserRepository()
+
+			// セットアップ
+			tt.setup(t, relationshipRepo, userRepo)
+
+			// UseCase作成
+			uc := NewRejectFriendRequestUseCase(relationshipRepo, userRepo)
+
+			// 実行
+			output, err := uc.Execute(ctx, tt.input)
+
+			// エラーチェック
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message = %v, want contains %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if tt.checkFunc != nil {
+					tt.checkFunc(t, output)
+				}
+			}
+		})
+	}
+}
+
+func TestRejectFriendRequestUseCase_Execute_UpdateTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	// リポジトリの初期化
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	// ユーザーを作成
+	requester := &entity.User{
+		ID:           "requester1",
+		Username:     "alice",
+		Email:        "alice@example.com",
+		PasswordHash: "hash",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	receiver := &entity.User{
+		ID:           "receiver1",
+		Username:     "bob",
+		Email:        "bob@example.com",
+		PasswordHash: "hash",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	if err := userRepo.Create(ctx, requester); err != nil {
+		t.Fatalf("failed to create requester: %v", err)
+	}
+	if err := userRepo.Create(ctx, receiver); err != nil {
+		t.Fatalf("failed to create receiver: %v", err)
+	}
+
+	// 古い更新日時で関係を作成
+	oldTime := time.Now().Add(-24 * time.Hour)
+	relationship := &entity.Relationship{
+		ID:          "rel1",
+		RequesterID: requester.ID,
+		ReceiverID:  receiver.ID,
+		Status:      valueobject.RelationshipStatusPending,
+		CreatedAt:   oldTime,
+		UpdatedAt:   oldTime,
+	}
+	if err := relationshipRepo.Create(ctx, relationship); err != nil {
+		t.Fatalf("failed to create relationship: %v", err)
+	}
+
+	// UseCase作成と実行
+	uc := NewRejectFriendRequestUseCase(relationshipRepo, userRepo)
+	input := RejectFriendRequestInput{
+		RelationshipID: "rel1",
+		ReceiverID:     receiver.ID,
+	}
+
+	beforeTime := time.Now()
+	output, err := uc.Execute(ctx, input)
+	afterTime := time.Now()
+
+	// エラーチェック
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 更新日時のチェック
+	if output.Relationship.UpdatedAt.Before(beforeTime) || output.Relationship.UpdatedAt.After(afterTime) {
+		t.Errorf("UpdatedAt = %v, want between %v and %v", output.Relationship.UpdatedAt, beforeTime, afterTime)
+	}
+
+	// 作成日時は変更されていないことを確認
+	if !output.Relationship.CreatedAt.Equal(oldTime) {
+		t.Errorf("CreatedAt was modified: got %v, want %v", output.Relationship.CreatedAt, oldTime)
+	}
+}


### PR DESCRIPTION
This pull request adds a new use case to handle the rejection of friend requests in the relationship domain. The main addition is the implementation of the `RejectFriendRequestUseCase`, which validates input, checks permissions, updates the relationship status, and ensures data integrity.

New friend request rejection feature:

* Added `RejectFriendRequestUseCase` in `internal/usecase/relationship/reject_friend_request.go`, including input/output types and the main logic for rejecting a friend request.
* Implemented validation for relationship ID and receiver ID, as well as permission checks to ensure only the request receiver can reject the request.
* Added status checks to prevent rejection of already accepted, rejected, or blocked requests, and handle only pending requests.
* Ensured data integrity by verifying both the requester and receiver exist before processing the rejection.
* Updated the relationship status and timestamp, and persisted the changes using the repository pattern.