### PR TITLE
feat: implement RemoveRelationship use case for relationship management

### DIFF
--- a/internal/usecase/relationship/block_user_test.go
+++ b/internal/usecase/relationship/block_user_test.go
@@ -410,4 +410,3 @@ func TestBlockUserUseCase_Execute(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/usecase/relationship/remove_relationship.go
+++ b/internal/usecase/relationship/remove_relationship.go
@@ -1,0 +1,157 @@
+package relationship
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ochamu/morning-call-api/internal/domain/repository"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+)
+
+// RemoveRelationshipUseCase は関係削除のユースケース
+type RemoveRelationshipUseCase struct {
+	relationshipRepo repository.RelationshipRepository
+	userRepo         repository.UserRepository
+}
+
+// NewRemoveRelationshipUseCase は新しい関係削除ユースケースを作成する
+func NewRemoveRelationshipUseCase(
+	relationshipRepo repository.RelationshipRepository,
+	userRepo repository.UserRepository,
+) *RemoveRelationshipUseCase {
+	return &RemoveRelationshipUseCase{
+		relationshipRepo: relationshipRepo,
+		userRepo:         userRepo,
+	}
+}
+
+// RemoveRelationshipInput は関係削除の入力データ
+type RemoveRelationshipInput struct {
+	RelationshipID string // 削除する関係ID
+	UserID         string // 削除を実行するユーザーID
+}
+
+// RemoveRelationshipOutput は関係削除の出力データ
+type RemoveRelationshipOutput struct {
+	Success bool
+	Message string
+}
+
+// Execute は関係を削除する
+func (uc *RemoveRelationshipUseCase) Execute(ctx context.Context, input RemoveRelationshipInput) (*RemoveRelationshipOutput, error) {
+	// 入力値の基本検証
+	if input.RelationshipID == "" {
+		return nil, fmt.Errorf("関係IDは必須です")
+	}
+	if input.UserID == "" {
+		return nil, fmt.Errorf("ユーザーIDは必須です")
+	}
+
+	// 削除実行者の存在確認
+	user, err := uc.userRepo.FindByID(ctx, input.UserID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("ユーザーが見つかりません")
+		}
+		return nil, fmt.Errorf("ユーザーの確認中にエラーが発生しました: %w", err)
+	}
+
+	// 関係の取得
+	relationship, err := uc.relationshipRepo.FindByID(ctx, input.RelationshipID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("関係が見つかりません")
+		}
+		return nil, fmt.Errorf("関係の取得中にエラーが発生しました: %w", err)
+	}
+
+	// 削除権限の確認
+	// 関係に含まれるユーザーのみが削除可能
+	if !relationship.InvolvesUser(user.ID) {
+		return nil, fmt.Errorf("この関係を削除する権限がありません")
+	}
+
+	// ステータスに基づく削除可否の判定
+	switch relationship.Status {
+	case valueobject.RelationshipStatusBlocked:
+		// ブロック関係は削除不可
+		// ブロック解除は別のユースケース（UnblockUser）で処理すべき
+		return nil, fmt.Errorf("ブロック関係は削除できません。先にブロックを解除してください")
+	case valueobject.RelationshipStatusAccepted:
+		// 友達関係の解除
+		// 両者が削除可能
+		if !relationship.InvolvesUser(user.ID) {
+			return nil, fmt.Errorf("友達関係の解除は当事者のみが実行できます")
+		}
+		// 削除処理を続行
+	case valueobject.RelationshipStatusPending:
+		// ペンディング中のリクエスト
+		// 送信者は取り下げ、受信者は削除（拒否とは異なる）として処理
+		if !relationship.InvolvesUser(user.ID) {
+			return nil, fmt.Errorf("友達リクエストの削除は当事者のみが実行できます")
+		}
+		// 削除処理を続行
+	case valueobject.RelationshipStatusRejected:
+		// 拒否済みのリクエスト
+		// 両者が削除可能（履歴のクリーンアップ）
+		if !relationship.InvolvesUser(user.ID) {
+			return nil, fmt.Errorf("拒否済みリクエストの削除は当事者のみが実行できます")
+		}
+		// 削除処理を続行
+	default:
+		return nil, fmt.Errorf("不正なステータスの関係です")
+	}
+
+	// 関係の相手ユーザーの存在確認（データ整合性のため）
+	otherUserID := relationship.GetOtherUserID(user.ID)
+	if otherUserID == "" {
+		return nil, fmt.Errorf("関係の相手ユーザーが特定できません")
+	}
+
+	otherUser, err := uc.userRepo.FindByID(ctx, otherUserID)
+	if err != nil {
+		// 相手ユーザーが存在しない場合でも削除は許可する（データクリーンアップのため）
+		if !errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("相手ユーザーの確認中にエラーが発生しました: %w", err)
+		}
+		// 相手ユーザーが削除されている場合のログ用
+		_ = otherUser
+	}
+
+	// リポジトリから削除
+	if err := uc.relationshipRepo.Delete(ctx, relationship.ID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("削除対象の関係が見つかりません")
+		}
+		return nil, fmt.Errorf("関係の削除に失敗しました: %w", err)
+	}
+
+	// 削除成功メッセージの生成
+	var message string
+	switch relationship.Status {
+	case valueobject.RelationshipStatusAccepted:
+		message = "友達関係を解除しました"
+	case valueobject.RelationshipStatusPending:
+		if relationship.IsRequester(user.ID) {
+			message = "友達リクエストを取り下げました"
+		} else {
+			message = "友達リクエストを削除しました"
+		}
+	case valueobject.RelationshipStatusRejected:
+		message = "拒否済みの友達リクエストを削除しました"
+	default:
+		message = "関係を削除しました"
+	}
+
+	// ログ出力（システムイベント）
+	// 実際の実装では、ここで関連するモーニングコールの削除や
+	// 通知サービスの呼び出しを行うことも考えられる
+	_ = user      // 削除実行者のログ用（将来の拡張用）
+	_ = otherUser // 相手ユーザーのログ用（将来の拡張用）
+
+	return &RemoveRelationshipOutput{
+		Success: true,
+		Message: message,
+	}, nil
+}

--- a/internal/usecase/relationship/remove_relationship_test.go
+++ b/internal/usecase/relationship/remove_relationship_test.go
@@ -1,0 +1,498 @@
+package relationship
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+	"github.com/ochamu/morning-call-api/internal/infrastructure/memory"
+)
+
+func TestNewRemoveRelationshipUseCase(t *testing.T) {
+	relationshipRepo := memory.NewRelationshipRepository()
+	userRepo := memory.NewUserRepository()
+
+	uc := NewRemoveRelationshipUseCase(relationshipRepo, userRepo)
+
+	if uc == nil {
+		t.Fatal("NewRemoveRelationshipUseCase returned nil")
+	}
+	if uc.relationshipRepo == nil {
+		t.Error("relationshipRepo is nil")
+	}
+	if uc.userRepo == nil {
+		t.Error("userRepo is nil")
+	}
+}
+
+func TestRemoveRelationshipUseCase_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	// テスト用ユーザーを作成
+	user1 := &entity.User{
+		ID:           "user1-id",
+		Username:     "user1",
+		Email:        "user1@example.com",
+		PasswordHash: "hashed",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	user2 := &entity.User{
+		ID:           "user2-id",
+		Username:     "user2",
+		Email:        "user2@example.com",
+		PasswordHash: "hashed",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	user3 := &entity.User{
+		ID:           "user3-id",
+		Username:     "user3",
+		Email:        "user3@example.com",
+		PasswordHash: "hashed",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	tests := []struct {
+		name      string
+		input     RemoveRelationshipInput
+		setup     func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository)
+		wantErr   bool
+		errMsg    string
+		checkFunc func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository)
+	}{
+		{
+			name: "成功ケース - 友達関係を解除（リクエスト送信者側から）",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-1",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+
+				// 承認済みの友達関係を作成
+				friendship := &entity.Relationship{
+					ID:          "rel-1",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusAccepted,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, friendship); err != nil {
+					t.Fatalf("failed to create friendship: %v", err)
+				}
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository) {
+				if !output.Success {
+					t.Error("Expected success to be true")
+				}
+				if output.Message != "友達関係を解除しました" {
+					t.Errorf("Message = %v, want %v", output.Message, "友達関係を解除しました")
+				}
+				// 関係が削除されていることを確認
+				if _, err := rr.FindByID(ctx, "rel-1"); err == nil {
+					t.Error("Relationship should have been deleted")
+				}
+			},
+		},
+		{
+			name: "成功ケース - 友達関係を解除（リクエスト受信者側から）",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-2",
+				UserID:         user2.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+
+				// 承認済みの友達関係を作成
+				friendship := &entity.Relationship{
+					ID:          "rel-2",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusAccepted,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, friendship); err != nil {
+					t.Fatalf("failed to create friendship: %v", err)
+				}
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository) {
+				if !output.Success {
+					t.Error("Expected success to be true")
+				}
+				if output.Message != "友達関係を解除しました" {
+					t.Errorf("Message = %v, want %v", output.Message, "友達関係を解除しました")
+				}
+			},
+		},
+		{
+			name: "成功ケース - ペンディングリクエストを取り下げ（送信者）",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-3",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+
+				// ペンディング状態の関係を作成
+				pending := &entity.Relationship{
+					ID:          "rel-3",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusPending,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, pending); err != nil {
+					t.Fatalf("failed to create pending relationship: %v", err)
+				}
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository) {
+				if !output.Success {
+					t.Error("Expected success to be true")
+				}
+				if output.Message != "友達リクエストを取り下げました" {
+					t.Errorf("Message = %v, want %v", output.Message, "友達リクエストを取り下げました")
+				}
+			},
+		},
+		{
+			name: "成功ケース - ペンディングリクエストを削除（受信者）",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-4",
+				UserID:         user2.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+
+				// ペンディング状態の関係を作成
+				pending := &entity.Relationship{
+					ID:          "rel-4",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusPending,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, pending); err != nil {
+					t.Fatalf("failed to create pending relationship: %v", err)
+				}
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository) {
+				if !output.Success {
+					t.Error("Expected success to be true")
+				}
+				if output.Message != "友達リクエストを削除しました" {
+					t.Errorf("Message = %v, want %v", output.Message, "友達リクエストを削除しました")
+				}
+			},
+		},
+		{
+			name: "成功ケース - 拒否済みリクエストを削除",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-5",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+
+				// 拒否済み状態の関係を作成
+				rejected := &entity.Relationship{
+					ID:          "rel-5",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusRejected,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, rejected); err != nil {
+					t.Fatalf("failed to create rejected relationship: %v", err)
+				}
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository) {
+				if !output.Success {
+					t.Error("Expected success to be true")
+				}
+				if output.Message != "拒否済みの友達リクエストを削除しました" {
+					t.Errorf("Message = %v, want %v", output.Message, "拒否済みの友達リクエストを削除しました")
+				}
+			},
+		},
+		{
+			name: "成功ケース - 相手ユーザーが削除済みでも削除可能",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-6",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				// user2は作成しない（削除済みユーザーをシミュレート）
+
+				// 友達関係を作成
+				friendship := &entity.Relationship{
+					ID:          "rel-6",
+					RequesterID: user1.ID,
+					ReceiverID:  "deleted-user-id",
+					Status:      valueobject.RelationshipStatusAccepted,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, friendship); err != nil {
+					t.Fatalf("failed to create friendship: %v", err)
+				}
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository) {
+				if !output.Success {
+					t.Error("Expected success to be true")
+				}
+			},
+		},
+		{
+			name: "エラー - ブロック関係は削除不可",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-7",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+
+				// ブロック関係を作成
+				blocked := &entity.Relationship{
+					ID:          "rel-7",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusBlocked,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, blocked); err != nil {
+					t.Fatalf("failed to create blocked relationship: %v", err)
+				}
+			},
+			wantErr: true,
+			errMsg:  "ブロック関係は削除できません。先にブロックを解除してください",
+		},
+		{
+			name: "エラー - 関係IDが空",
+			input: RemoveRelationshipInput{
+				RelationshipID: "",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				// セットアップ不要
+			},
+			wantErr: true,
+			errMsg:  "関係IDは必須です",
+		},
+		{
+			name: "エラー - ユーザーIDが空",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-8",
+				UserID:         "",
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				// セットアップ不要
+			},
+			wantErr: true,
+			errMsg:  "ユーザーIDは必須です",
+		},
+		{
+			name: "エラー - ユーザーが存在しない",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-9",
+				UserID:         "nonexistent",
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				// ユーザーを作成しない
+			},
+			wantErr: true,
+			errMsg:  "ユーザーが見つかりません",
+		},
+		{
+			name: "エラー - 関係が存在しない",
+			input: RemoveRelationshipInput{
+				RelationshipID: "nonexistent",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+			},
+			wantErr: true,
+			errMsg:  "関係が見つかりません",
+		},
+		{
+			name: "エラー - 削除権限がない（第三者）",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-10",
+				UserID:         user3.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+				if err := ur.Create(ctx, user3); err != nil {
+					t.Fatalf("failed to create user3: %v", err)
+				}
+
+				// user1とuser2の関係を作成
+				friendship := &entity.Relationship{
+					ID:          "rel-10",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusAccepted,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, friendship); err != nil {
+					t.Fatalf("failed to create friendship: %v", err)
+				}
+			},
+			wantErr: true,
+			errMsg:  "この関係を削除する権限がありません",
+		},
+		{
+			name: "成功ケース - 第三者の関係は影響しない",
+			input: RemoveRelationshipInput{
+				RelationshipID: "rel-11",
+				UserID:         user1.ID,
+			},
+			setup: func(t *testing.T, rr *memory.RelationshipRepository, ur *memory.UserRepository) {
+				if err := ur.Create(ctx, user1); err != nil {
+					t.Fatalf("failed to create user1: %v", err)
+				}
+				if err := ur.Create(ctx, user2); err != nil {
+					t.Fatalf("failed to create user2: %v", err)
+				}
+				if err := ur.Create(ctx, user3); err != nil {
+					t.Fatalf("failed to create user3: %v", err)
+				}
+
+				// user1とuser2の関係
+				rel1 := &entity.Relationship{
+					ID:          "rel-11",
+					RequesterID: user1.ID,
+					ReceiverID:  user2.ID,
+					Status:      valueobject.RelationshipStatusAccepted,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, rel1); err != nil {
+					t.Fatalf("failed to create rel1: %v", err)
+				}
+
+				// user2とuser3の関係（影響を受けない）
+				rel2 := &entity.Relationship{
+					ID:          "rel-12",
+					RequesterID: user2.ID,
+					ReceiverID:  user3.ID,
+					Status:      valueobject.RelationshipStatusAccepted,
+					CreatedAt:   time.Now(),
+					UpdatedAt:   time.Now(),
+				}
+				if err := rr.Create(ctx, rel2); err != nil {
+					t.Fatalf("failed to create rel2: %v", err)
+				}
+			},
+			wantErr: false,
+			checkFunc: func(t *testing.T, output *RemoveRelationshipOutput, rr *memory.RelationshipRepository) {
+				// rel-11は削除されている
+				if _, err := rr.FindByID(ctx, "rel-11"); err == nil {
+					t.Error("rel-11 should have been deleted")
+				}
+				// rel-12は影響を受けない
+				rel2, err := rr.FindByID(ctx, "rel-12")
+				if err != nil {
+					t.Errorf("rel-12 should still exist: %v", err)
+				}
+				if rel2.Status != valueobject.RelationshipStatusAccepted {
+					t.Error("rel-12 status should not be affected")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 各テストケースで新しいリポジトリを作成
+			relationshipRepo := memory.NewRelationshipRepository()
+			userRepo := memory.NewUserRepository()
+
+			// セットアップを実行
+			if tt.setup != nil {
+				tt.setup(t, relationshipRepo, userRepo)
+			}
+
+			// UseCaseを作成して実行
+			uc := NewRemoveRelationshipUseCase(relationshipRepo, userRepo)
+			output, err := uc.Execute(ctx, tt.input)
+
+			// エラーチェック
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message = %v, want contains %v", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				// 追加のチェック
+				if tt.checkFunc != nil {
+					tt.checkFunc(t, output, relationshipRepo)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a new use case for removing relationships between users, including comprehensive validation and permission checks. The main addition is the implementation of the `RemoveRelationshipUseCase`, which handles the process of deleting a relationship, ensuring only authorized users can perform the action, and providing appropriate feedback messages based on the relationship status.

### New relationship removal feature

* Added `RemoveRelationshipUseCase` in `internal/usecase/relationship/remove_relationship.go`, including input/output types and the main `Execute` method for deleting relationships with validation, permission checks, and status-specific logic.

No other significant changes were made.