### PR TITLE
feat: RelationshipHandlerとDTOを実装

### DIFF
--- a/internal/handler/dto/request/relationship.go
+++ b/internal/handler/dto/request/relationship.go
@@ -1,0 +1,26 @@
+package request
+
+// SendFriendRequest は友達リクエスト送信のリクエスト
+type SendFriendRequest struct {
+	ReceiverID string `json:"receiver_id"`
+}
+
+// AcceptFriendRequest は友達リクエスト承認のリクエスト
+type AcceptFriendRequest struct {
+	RelationshipID string `json:"relationship_id"`
+}
+
+// RejectFriendRequest は友達リクエスト拒否のリクエスト
+type RejectFriendRequest struct {
+	RelationshipID string `json:"relationship_id"`
+}
+
+// BlockUserRequest はユーザーブロックのリクエスト
+type BlockUserRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// RemoveRelationshipRequest は関係削除のリクエスト
+type RemoveRelationshipRequest struct {
+	RelationshipID string `json:"relationship_id"`
+}

--- a/internal/handler/dto/response/relationship.go
+++ b/internal/handler/dto/response/relationship.go
@@ -1,0 +1,62 @@
+package response
+
+import (
+	"time"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/domain/valueobject"
+)
+
+// RelationshipResponse はRelationshipのレスポンス
+type RelationshipResponse struct {
+	ID          string                         `json:"id"`
+	RequesterID string                         `json:"requester_id"`
+	ReceiverID  string                         `json:"receiver_id"`
+	Status      valueobject.RelationshipStatus `json:"status"`
+	CreatedAt   time.Time                      `json:"created_at"`
+	UpdatedAt   time.Time                      `json:"updated_at"`
+}
+
+// NewRelationshipResponse はentityからレスポンスを作成
+func NewRelationshipResponse(r *entity.Relationship) *RelationshipResponse {
+	return &RelationshipResponse{
+		ID:          r.ID,
+		RequesterID: r.RequesterID,
+		ReceiverID:  r.ReceiverID,
+		Status:      r.Status,
+		CreatedAt:   r.CreatedAt,
+		UpdatedAt:   r.UpdatedAt,
+	}
+}
+
+// RelationshipListResponse は関係一覧のレスポンス
+type RelationshipListResponse struct {
+	Relationships []*RelationshipResponse `json:"relationships"`
+	Total         int                     `json:"total"`
+}
+
+// NewRelationshipListResponse はentityのスライスからレスポンスを作成
+func NewRelationshipListResponse(relationships []*entity.Relationship) *RelationshipListResponse {
+	res := &RelationshipListResponse{
+		Relationships: make([]*RelationshipResponse, 0, len(relationships)),
+		Total:         len(relationships),
+	}
+	for _, r := range relationships {
+		res.Relationships = append(res.Relationships, NewRelationshipResponse(r))
+	}
+	return res
+}
+
+// FriendResponse は友達情報のレスポンス
+type FriendResponse struct {
+	ID          string    `json:"id"`
+	Username    string    `json:"username"`
+	Email       string    `json:"email"`
+	FriendSince time.Time `json:"friend_since"`
+}
+
+// FriendListResponse は友達一覧のレスポンス
+type FriendListResponse struct {
+	Friends []*FriendResponse `json:"friends"`
+	Total   int               `json:"total"`
+}

--- a/internal/handler/relationship_handler.go
+++ b/internal/handler/relationship_handler.go
@@ -1,0 +1,348 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/ochamu/morning-call-api/internal/domain/entity"
+	"github.com/ochamu/morning-call-api/internal/handler/dto/request"
+	"github.com/ochamu/morning-call-api/internal/handler/dto/response"
+	"github.com/ochamu/morning-call-api/internal/infrastructure/auth"
+	relUseCase "github.com/ochamu/morning-call-api/internal/usecase/relationship"
+	"github.com/ochamu/morning-call-api/internal/usecase/user"
+)
+
+// RelationshipHandler は友達関係関連のHTTPハンドラー
+type RelationshipHandler struct {
+	*BaseHandler
+	sendFriendRequestUC   *relUseCase.SendFriendRequestUseCase
+	acceptFriendRequestUC *relUseCase.AcceptFriendRequestUseCase
+	rejectFriendRequestUC *relUseCase.RejectFriendRequestUseCase
+	blockUserUC           *relUseCase.BlockUserUseCase
+	removeRelationshipUC  *relUseCase.RemoveRelationshipUseCase
+	listFriendsUC         *relUseCase.ListFriendsUseCase
+	listFriendRequestsUC  *relUseCase.ListFriendRequestsUseCase
+	userUC                *user.UserUseCase
+	sessionManager        *auth.SessionManager
+}
+
+// NewRelationshipHandler は新しいRelationshipHandlerを作成する
+func NewRelationshipHandler(
+	sendFriendRequestUC *relUseCase.SendFriendRequestUseCase,
+	acceptFriendRequestUC *relUseCase.AcceptFriendRequestUseCase,
+	rejectFriendRequestUC *relUseCase.RejectFriendRequestUseCase,
+	blockUserUC *relUseCase.BlockUserUseCase,
+	removeRelationshipUC *relUseCase.RemoveRelationshipUseCase,
+	listFriendsUC *relUseCase.ListFriendsUseCase,
+	listFriendRequestsUC *relUseCase.ListFriendRequestsUseCase,
+	userUC *user.UserUseCase,
+	sessionManager *auth.SessionManager,
+) *RelationshipHandler {
+	return &RelationshipHandler{
+		BaseHandler:           &BaseHandler{},
+		sendFriendRequestUC:   sendFriendRequestUC,
+		acceptFriendRequestUC: acceptFriendRequestUC,
+		rejectFriendRequestUC: rejectFriendRequestUC,
+		blockUserUC:           blockUserUC,
+		removeRelationshipUC:  removeRelationshipUC,
+		listFriendsUC:         listFriendsUC,
+		listFriendRequestsUC:  listFriendRequestsUC,
+		userUC:                userUC,
+		sessionManager:        sessionManager,
+	}
+}
+
+// HandleSendFriendRequest は友達リクエスト送信のハンドラー
+func (h *RelationshipHandler) HandleSendFriendRequest(w http.ResponseWriter, r *http.Request) {
+	// 認証チェック
+	currentUser, err := h.GetUserFromContext(r.Context())
+	if err != nil {
+		h.SendAuthenticationError(w)
+		return
+	}
+
+	// リクエストボディの解析
+	var req request.SendFriendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.SendError(w, http.StatusBadRequest, "PARSE_ERROR", "リクエストの形式が正しくありません", nil)
+		return
+	}
+
+	// 入力検証
+	if req.ReceiverID == "" {
+		h.SendError(w, http.StatusBadRequest, "VALIDATION_ERROR", "宛先ユーザーIDが必要です", nil)
+		return
+	}
+
+	// 友達リクエスト送信
+	output, err := h.sendFriendRequestUC.Execute(r.Context(), relUseCase.SendFriendRequestInput{
+		RequesterID: currentUser.ID,
+		ReceiverID:  req.ReceiverID,
+	})
+	if err != nil {
+		// エラー内容に応じて適切なレスポンスを返す
+		if strings.Contains(err.Error(), "既に") || strings.Contains(err.Error(), "ブロック") {
+			h.SendError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), nil)
+			return
+		}
+		if strings.Contains(err.Error(), "見つかりません") {
+			h.SendError(w, http.StatusNotFound, "NOT_FOUND", err.Error(), nil)
+			return
+		}
+		h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "友達リクエストの送信に失敗しました", nil)
+		return
+	}
+
+	// レスポンス
+	h.SendJSON(w, http.StatusCreated, response.NewRelationshipResponse(output.Relationship))
+}
+
+// HandleAcceptFriendRequest は友達リクエスト承認のハンドラー
+func (h *RelationshipHandler) HandleAcceptFriendRequest(w http.ResponseWriter, r *http.Request) {
+	// 認証チェック
+	currentUser, err := h.GetUserFromContext(r.Context())
+	if err != nil {
+		h.SendAuthenticationError(w)
+		return
+	}
+
+	// URLパラメータから関係IDを取得
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 5 || parts[len(parts)-1] != "accept" {
+		h.SendError(w, http.StatusBadRequest, "INVALID_REQUEST", "無効なリクエストパスです", nil)
+		return
+	}
+	relationshipID := parts[len(parts)-2]
+
+	// 友達リクエスト承認
+	output, err := h.acceptFriendRequestUC.Execute(r.Context(), relUseCase.AcceptFriendRequestInput{
+		RelationshipID: relationshipID,
+		ReceiverID:     currentUser.ID,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "見つかりません") {
+			h.SendError(w, http.StatusNotFound, "NOT_FOUND", err.Error(), nil)
+			return
+		}
+		if strings.Contains(err.Error(), "権限") || strings.Contains(err.Error(), "承認できません") {
+			h.SendError(w, http.StatusForbidden, "FORBIDDEN", err.Error(), nil)
+			return
+		}
+		h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "友達リクエストの承認に失敗しました", nil)
+		return
+	}
+
+	// レスポンス
+	h.SendJSON(w, http.StatusOK, response.NewRelationshipResponse(output.Relationship))
+}
+
+// HandleRejectFriendRequest は友達リクエスト拒否のハンドラー
+func (h *RelationshipHandler) HandleRejectFriendRequest(w http.ResponseWriter, r *http.Request) {
+	// 認証チェック
+	currentUser, err := h.GetUserFromContext(r.Context())
+	if err != nil {
+		h.SendAuthenticationError(w)
+		return
+	}
+
+	// URLパラメータから関係IDを取得
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 5 || parts[len(parts)-1] != "reject" {
+		h.SendError(w, http.StatusBadRequest, "INVALID_REQUEST", "無効なリクエストパスです", nil)
+		return
+	}
+	relationshipID := parts[len(parts)-2]
+
+	// 友達リクエスト拒否
+	output, err := h.rejectFriendRequestUC.Execute(r.Context(), relUseCase.RejectFriendRequestInput{
+		RelationshipID: relationshipID,
+		ReceiverID:     currentUser.ID,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "見つかりません") {
+			h.SendError(w, http.StatusNotFound, "NOT_FOUND", err.Error(), nil)
+			return
+		}
+		if strings.Contains(err.Error(), "権限") || strings.Contains(err.Error(), "拒否できません") {
+			h.SendError(w, http.StatusForbidden, "FORBIDDEN", err.Error(), nil)
+			return
+		}
+		h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "友達リクエストの拒否に失敗しました", nil)
+		return
+	}
+
+	// レスポンス
+	if output != nil {
+		h.SendJSON(w, http.StatusOK, response.NewRelationshipResponse(output.Relationship))
+	} else {
+		h.SendJSON(w, http.StatusNoContent, nil)
+	}
+}
+
+// HandleBlockUser はユーザーブロックのハンドラー
+func (h *RelationshipHandler) HandleBlockUser(w http.ResponseWriter, r *http.Request) {
+	// 認証チェック
+	currentUser, err := h.GetUserFromContext(r.Context())
+	if err != nil {
+		h.SendAuthenticationError(w)
+		return
+	}
+
+	// URLパラメータからユーザーIDを取得
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 5 || parts[len(parts)-1] != "block" {
+		h.SendError(w, http.StatusBadRequest, "INVALID_REQUEST", "無効なリクエストパスです", nil)
+		return
+	}
+	targetUserID := parts[len(parts)-2]
+
+	// ユーザーブロック
+	output, err := h.blockUserUC.Execute(r.Context(), relUseCase.BlockUserInput{
+		BlockerID: currentUser.ID,
+		BlockedID: targetUserID,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "見つかりません") {
+			h.SendError(w, http.StatusNotFound, "NOT_FOUND", err.Error(), nil)
+			return
+		}
+		if strings.Contains(err.Error(), "自分自身") {
+			h.SendError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), nil)
+			return
+		}
+		h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "ユーザーのブロックに失敗しました", nil)
+		return
+	}
+
+	// レスポンス
+	h.SendJSON(w, http.StatusOK, response.NewRelationshipResponse(output.Relationship))
+}
+
+// HandleRemoveRelationship は関係削除のハンドラー
+func (h *RelationshipHandler) HandleRemoveRelationship(w http.ResponseWriter, r *http.Request) {
+	// 認証チェック
+	currentUser, err := h.GetUserFromContext(r.Context())
+	if err != nil {
+		h.SendAuthenticationError(w)
+		return
+	}
+
+	// URLパラメータから関係IDを取得
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 4 {
+		h.SendError(w, http.StatusBadRequest, "INVALID_REQUEST", "無効なリクエストパスです", nil)
+		return
+	}
+	relationshipID := parts[len(parts)-1]
+
+	// 関係削除
+	_, err = h.removeRelationshipUC.Execute(r.Context(), relUseCase.RemoveRelationshipInput{
+		RelationshipID: relationshipID,
+		UserID:         currentUser.ID,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "見つかりません") {
+			h.SendError(w, http.StatusNotFound, "NOT_FOUND", err.Error(), nil)
+			return
+		}
+		if strings.Contains(err.Error(), "権限") {
+			h.SendError(w, http.StatusForbidden, "FORBIDDEN", err.Error(), nil)
+			return
+		}
+		h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "関係の削除に失敗しました", nil)
+		return
+	}
+
+	// レスポンス
+	h.SendJSON(w, http.StatusNoContent, nil)
+}
+
+// HandleListFriends は友達一覧取得のハンドラー
+func (h *RelationshipHandler) HandleListFriends(w http.ResponseWriter, r *http.Request) {
+	// 認証チェック
+	currentUser, err := h.GetUserFromContext(r.Context())
+	if err != nil {
+		h.SendAuthenticationError(w)
+		return
+	}
+
+	// 友達一覧取得
+	output, err := h.listFriendsUC.Execute(r.Context(), relUseCase.ListFriendsInput{
+		UserID: currentUser.ID,
+	})
+	if err != nil {
+		h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "友達一覧の取得に失敗しました", nil)
+		return
+	}
+
+	// 友達情報を取得して詳細なレスポンスを作成
+	friendResponses := make([]*response.FriendResponse, 0, len(output.Friends))
+	for _, friendInfo := range output.Friends {
+		friendResponses = append(friendResponses, &response.FriendResponse{
+			ID:          friendInfo.User.ID,
+			Username:    friendInfo.User.Username,
+			Email:       friendInfo.User.Email,
+			FriendSince: friendInfo.Relationship.UpdatedAt, // 友達になった日時
+		})
+	}
+
+	// レスポンス
+	h.SendJSON(w, http.StatusOK, &response.FriendListResponse{
+		Friends: friendResponses,
+		Total:   len(friendResponses),
+	})
+}
+
+// HandleListFriendRequests は友達リクエスト一覧取得のハンドラー
+func (h *RelationshipHandler) HandleListFriendRequests(w http.ResponseWriter, r *http.Request) {
+	// 認証チェック
+	currentUser, err := h.GetUserFromContext(r.Context())
+	if err != nil {
+		h.SendAuthenticationError(w)
+		return
+	}
+
+	// クエリパラメータで方向を指定（sent/received）
+	direction := r.URL.Query().Get("direction")
+	if direction == "" {
+		direction = "received" // デフォルトは受信したリクエスト
+	}
+
+	// 友達リクエスト一覧取得
+	var relationships []*entity.Relationship
+	switch direction {
+	case "sent":
+		// 送信した友達リクエスト
+		output, err := h.listFriendRequestsUC.Execute(r.Context(), relUseCase.ListFriendRequestsInput{
+			UserID: currentUser.ID,
+			Type:   "sent",
+		})
+		if err != nil {
+			h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "友達リクエスト一覧の取得に失敗しました", nil)
+			return
+		}
+		for _, reqInfo := range output.Requests {
+			relationships = append(relationships, reqInfo.Relationship)
+		}
+	case "received":
+		// 受信した友達リクエスト
+		output, err := h.listFriendRequestsUC.Execute(r.Context(), relUseCase.ListFriendRequestsInput{
+			UserID: currentUser.ID,
+			Type:   "received",
+		})
+		if err != nil {
+			h.SendError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "友達リクエスト一覧の取得に失敗しました", nil)
+			return
+		}
+		for _, reqInfo := range output.Requests {
+			relationships = append(relationships, reqInfo.Relationship)
+		}
+	default:
+		h.SendError(w, http.StatusBadRequest, "INVALID_REQUEST", "無効な方向指定です（sent/receivedのいずれかを指定してください）", nil)
+		return
+	}
+
+	// レスポンス
+	h.SendJSON(w, http.StatusOK, response.NewRelationshipListResponse(relationships))
+}


### PR DESCRIPTION
## 概要
友達関係管理のためのHTTPハンドラーとDTOを実装しました。

## 実装内容
### RelationshipHandler
- 友達リクエスト送信 (`HandleSendFriendRequest`)
- 友達リクエスト承認 (`HandleAcceptFriendRequest`)
- 友達リクエスト拒否 (`HandleRejectFriendRequest`)
- ユーザーブロック (`HandleBlockUser`)
- 関係削除 (`HandleRemoveRelationship`)
- 友達一覧取得 (`HandleListFriends`)
- 友達リクエスト一覧取得 (`HandleListFriendRequests`)

### DTO
- リクエストDTO (`internal/handler/dto/request/relationship.go`)
- レスポンスDTO (`internal/handler/dto/response/relationship.go`)

## テスト計画
- [x] ハンドラーのコンパイル確認
- [ ] 統合テスト（別PR）

🤖 Generated with [Claude Code](https://claude.ai/code)